### PR TITLE
kev/151_reload_bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ numbers.
 
 ## 0.6 Future Release
 
++ Fix security key reloads bug, change button text colour. [0.5.26] 
 + Add version number to login screen. [0.5.25]
 + Fix login animation won't disappear in some cases. [0.5.24]
 + Implement API for changing "security key". [0.5.23]

--- a/lib/src/widgets/security_key_input.dart
+++ b/lib/src/widgets/security_key_input.dart
@@ -95,46 +95,50 @@ class _SecurityKeyInputState extends State<SecurityKeyInput> {
                       ),
                     ),
                     const SizedBox(height: 10),
-                    FormBuilderTextField(
-                      name: inputKey,
-                      obscureText:
-                          // Controls whether the security key is shown or hidden.
-                          !_showKey,
-                      autocorrect: false,
-                      decoration: InputDecoration(
-                        labelText: 'SECURITY KEY',
-                        labelStyle: const TextStyle(
-                          color: Colors.blue,
-                          letterSpacing: 1.5,
-                          fontSize: 13.0,
-                          fontWeight: FontWeight.bold,
-                        ),
-                        suffixIcon: IconButton(
-                          icon: Icon(_showKey
-                              ? Icons.visibility
-                              : Icons.visibility_off),
-                          onPressed: () {
-                            setState(() {
-                              // Toggle the state to show/hide the security key.
-                              _showKey = !_showKey;
-                            });
-                          },
-                        ),
-                      ),
-                      validator: FormBuilderValidators.compose([
-                        FormBuilderValidators.required(),
-                        (val) {
-                          if (!widget.verifySecurityKeyFunc(val as String)) {
-                            keyVerified = false;
-                            debugPrint('keyVerified: $keyVerified');
-                            return 'Incorrect Security Key';
-                          } else {
-                            keyVerified = true;
-                            debugPrint('keyVerified: $keyVerified');
-                          }
-                          return null;
-                        },
-                      ]),
+                    StatefulBuilder(
+                      builder: (BuildContext context, StateSetter setState) {
+                        return FormBuilderTextField(
+                          name: inputKey,
+                          obscureText:
+                              !_showKey, // Controls whether the security key is shown or hidden.
+                          autocorrect: false,
+                          decoration: InputDecoration(
+                            labelText: 'SECURITY KEY',
+                            labelStyle: const TextStyle(
+                              color: Colors.blue,
+                              letterSpacing: 1.5,
+                              fontSize: 13.0,
+                              fontWeight: FontWeight.bold,
+                            ),
+                            suffixIcon: IconButton(
+                              icon: Icon(_showKey
+                                  ? Icons.visibility
+                                  : Icons.visibility_off),
+                              onPressed: () {
+                                setState(() {
+                                  // Toggle the state to show/hide the security key.
+                                  _showKey = !_showKey;
+                                });
+                              },
+                            ),
+                          ),
+                          validator: FormBuilderValidators.compose([
+                            FormBuilderValidators.required(),
+                            (val) {
+                              if (!widget
+                                  .verifySecurityKeyFunc(val as String)) {
+                                keyVerified = false;
+                                debugPrint('keyVerified: $keyVerified');
+                                return 'Incorrect Security Key';
+                              } else {
+                                keyVerified = true;
+                                debugPrint('keyVerified: $keyVerified');
+                              }
+                              return null;
+                            },
+                          ]),
+                        );
+                      },
                     ),
                   ],
                 ),
@@ -143,7 +147,6 @@ class _SecurityKeyInputState extends State<SecurityKeyInput> {
               Row(crossAxisAlignment: CrossAxisAlignment.start, children: [
                 ElevatedButton(
                     onPressed: () async {
-                      //(formKey.currentState?.validate() ?? true)
                       if (keyVerified) {
                         debugPrint('keyVerified: $keyVerified');
                         final formData = formKey.currentState?.value as Map;
@@ -171,7 +174,7 @@ class _SecurityKeyInputState extends State<SecurityKeyInput> {
                     },
                     child: const Text(
                       'OK',
-                      style: TextStyle(color: Colors.white, fontSize: 12),
+                      style: TextStyle(color: Colors.black, fontSize: 12),
                     )),
                 const SizedBox(width: 10),
                 ElevatedButton(
@@ -183,7 +186,7 @@ class _SecurityKeyInputState extends State<SecurityKeyInput> {
                     },
                     child: const Text(
                       'Cancel',
-                      style: TextStyle(color: Colors.white, fontSize: 12),
+                      style: TextStyle(color: Colors.black, fontSize: 12),
                     ))
               ]),
             ])));


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- fixed security key reloads bug, change button text colour

- Link to associated issue: #151 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [ ] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [x] Chrome
  - [ ] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
- [ ] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev
