### PR TITLE
dc/160 support no encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ numbers.
 
 ## 0.6 Future Release
 
++ Support the read/write of non-encrypted data file. [0.5.28].
 + Refactor POD initialisation code. [0.5.27]
 + Fix security key reloads bug, change button text colour. [0.5.26] 
 + Add version number to login screen. [0.5.25]

--- a/lib/src/screens/initial_setup/widgets/res_create_form_submission.dart
+++ b/lib/src/screens/initial_setup/widgets/res_create_form_submission.dart
@@ -69,7 +69,7 @@ ElevatedButton resCreateFormSubmission(
       screenWidth < 360; // A threshold for small devices, can be adjusted.
 
   // The (updated) original version of POD initialisation function
-  Future<void> _initPod(String securityKey) async {
+  Future<void> _initPodOriginalFunc(String securityKey) async {
     final webId = await AuthDataManager.getWebId();
     assert(webId != null);
 
@@ -121,7 +121,8 @@ ElevatedButton resCreateFormSubmission(
     } else {
       try {
         for (final resLink in resFoldersLink) {
-          await createResource(resLink, fileFlag: false);
+          await createResource(resLink,
+              fileFlag: false, contentType: ContentType.directory);
         }
 
         // Create files
@@ -173,7 +174,7 @@ ElevatedButton resCreateFormSubmission(
         final securityKey = formData[securityKeyStr].toString();
 
         try {
-          // await _initPod(securityKey);
+          // await _initPodOriginalFunc(securityKey);
           await initPod(securityKey,
               dirUrls: resFoldersLink, fileUrls: resFilesLink);
         } on Exception catch (e) {

--- a/lib/src/solid/api/rest_api.dart
+++ b/lib/src/solid/api/rest_api.dart
@@ -152,12 +152,14 @@ Future<List<dynamic>> initialStructureTest(
 Future<void> createResource(String resourceUrl,
     {String content = '',
     bool fileFlag = true,
-    bool replaceIfExist = false}) async {
+    bool replaceIfExist = false,
+    ContentType contentType = ContentType.turtleText}) async {
   // Sanity check
   if (fileFlag) {
     assert(!resourceUrl.endsWith('/'));
   } else {
     assert(resourceUrl.endsWith('/'));
+    assert(contentType == ContentType.directory);
   }
 
   // Use PUT request for creating and replacing a file if it already exists
@@ -188,7 +190,7 @@ Future<void> createResource(String resourceUrl,
       'Accept': '*/*',
       'Authorization': 'DPoP $accessToken',
       'Connection': 'keep-alive',
-      'Content-Type': fileFlag ? fileContentType : dirContentType,
+      'Content-Type': contentType.value,
       if (put) 'Content-Length': content.length.toString(),
       if (!put) 'Link': fileFlag ? fileTypeLink : dirTypeLink,
       if (!put) 'Slug': name,
@@ -207,7 +209,8 @@ Future<void> createResource(String resourceUrl,
 }
 
 /// Delete a file or a directory
-Future<void> deleteResource(bool fileFlag, String itemLoc) async {
+Future<void> deleteResource(bool fileFlag, String itemLoc,
+    {required ContentType contentType}) async {
   final resourceUrl =
       fileFlag ? await getFileUrl(itemLoc) : await getDirUrl(itemLoc);
   final (:accessToken, :dPopToken) =
@@ -219,7 +222,7 @@ Future<void> deleteResource(bool fileFlag, String itemLoc) async {
       'Accept': '*/*',
       'Authorization': 'DPoP $accessToken',
       'Connection': 'keep-alive',
-      'Content-Type': fileFlag ? fileContentType : dirContentType,
+      'Content-Type': contentType.value,
       'DPoP': dPopToken,
     },
   );
@@ -239,7 +242,8 @@ Future<ResourceStatus> checkResourceStatus(String resUrl, bool fileFlag) async {
   final response = await http.get(
     Uri.parse(resUrl),
     headers: <String, String>{
-      'Content-Type': fileFlag ? '*/*' : dirContentType,
+      'Content-Type':
+          fileFlag ? ContentType.any.value : ContentType.directory.value,
       'Authorization': 'DPoP $accessToken',
       'Link': fileFlag ? fileTypeLink : dirTypeLink,
       'DPoP': dPopToken,

--- a/lib/src/solid/constants.dart
+++ b/lib/src/solid/constants.dart
@@ -96,8 +96,6 @@ const String rdfSyntax = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#';
 
 /// String variables for creating files and directories on solid server
 
-const String fileContentType = 'text/turtle';
-const String dirContentType = 'application/octet-stream';
 const String fileTypeLink = '<http://www.w3.org/ns/ldp#Resource>; rel="type"';
 const String dirTypeLink =
     '<http://www.w3.org/ns/ldp#BasicContainer>; rel="type"';
@@ -128,6 +126,27 @@ enum ResourceStatus {
 
   /// Do not know if the resource exist (e.g. error occurred when checking the status)
   unknown
+}
+
+/// Types of the content of resources
+enum ContentType {
+  /// TTL text file
+  turtleText('text/turtle'),
+
+  /// Plain text file
+  plainText('text/plain'),
+
+  /// Directory
+  directory('application/octet-stream'),
+
+  /// Any
+  any('*/*');
+
+  /// Constructor
+  const ContentType(this.value);
+
+  /// String value of the access type
+  final String value;
 }
 
 /// Types of access to a resource

--- a/lib/src/solid/read_pod.dart
+++ b/lib/src/solid/read_pod.dart
@@ -62,9 +62,9 @@ Future<String?> readPod(
     try {
       final fileContent = await fetchPrvFile(fileUrl);
 
-      // Decrypt if reading a data file (which is encrypted)
+      // Decrypt if reading an encrypted file
 
-      if (path.split(filePath)[1] == dataDir) {
+      if (await KeyManager.hasIndividualKey(fileUrl)) {
         await getKeyFromUserIfRequired(context, child);
 
         // Get the individual key for the file
@@ -81,8 +81,10 @@ Future<String?> readPod(
         return fileContent;
       }
     } on Exception catch (e) {
-      print('Exception: $e');
+      debugPrint(e.toString());
     }
   }
+
+  debugPrint('Resource "$filePath" does not exist.');
   return null;
 }

--- a/lib/src/solid/utils/misc.dart
+++ b/lib/src/solid/utils/misc.dart
@@ -359,7 +359,8 @@ Future<void> initPod(String securityKey,
   // Create the required directories
 
   for (final d in dirUrls) {
-    await createResource(d, fileFlag: false);
+    await createResource(d,
+        fileFlag: false, contentType: ContentType.directory);
   }
 
   // Check (and generate) the file URLs

--- a/lib/src/solid/write_pod.dart
+++ b/lib/src/solid/write_pod.dart
@@ -44,11 +44,11 @@ import 'package:solidpod/src/solid/utils/key_management.dart';
 import 'package:solidpod/src/solid/utils/misc.dart';
 
 /// Write file [fileName] and content [fileContent] to PODs
-/// The content will be encrypted if [encryptContent] is true.
+/// The content will be encrypted if [encrypted] is true.
 
 Future<void> writePod(
     String fileName, String fileContent, BuildContext context, Widget child,
-    {bool encryptContent = true}) async {
+    {bool encrypted = true}) async {
   // Write data to file in the data directory
   final filePath = path.join(await getDataDirPath(), fileName);
 
@@ -62,7 +62,7 @@ Future<void> writePod(
   final replace = fileExists == ResourceStatus.exist ? true : false;
   late final String content;
 
-  if (encryptContent) {
+  if (encrypted) {
     // Get the security key (and cache it in KeyManager)
     await getKeyFromUserIfRequired(context, child);
 

--- a/lib/src/solid/write_pod.dart
+++ b/lib/src/solid/write_pod.dart
@@ -44,73 +44,52 @@ import 'package:solidpod/src/solid/utils/key_management.dart';
 import 'package:solidpod/src/solid/utils/misc.dart';
 
 /// Write file [fileName] and content [fileContent] to PODs
+/// The content will be encrypted if [encryptContent] is true.
 
-Future<void> writePod(String fileName, String fileContent, BuildContext context,
-    Widget child) async {
+Future<void> writePod(
+    String fileName, String fileContent, BuildContext context, Widget child,
+    {bool encryptContent = true}) async {
   // Write data to file in the data directory
   final filePath = path.join(await getDataDirPath(), fileName);
 
   await loginIfRequired(context);
-
-  await getKeyFromUserIfRequired(context, child);
-
-  // Get master key for encryption
-
-  // final securityKey = await getVerifiedSecurityKey(context, child);
-  // final masterKey = genMasterKey(securityKey);
 
   // Check if the file already exists
 
   final fileUrl = await getFileUrl(filePath);
   final fileExists = await checkResourceStatus(fileUrl, true);
 
-  // Reuse the individual key if the file already exists
-  late final Key indKey;
-  late final bool replace;
+  final replace = fileExists == ResourceStatus.exist ? true : false;
+  late final String content;
 
-  if (fileExists == ResourceStatus.exist) {
-    replace = true;
-    // Delete the existing file
+  if (encryptContent) {
+    // Get the security key (and cache it in KeyManager)
+    await getKeyFromUserIfRequired(context, child);
 
-    // try {
-    //   await deleteItem(true, filePath);
-    // } on Exception catch (e) {
-    //   print('Exception: $e');
-    // }
+    late final Key indKey;
 
-    // Get (and decrypt) the individual key from ind-key file
-    // (the TTL file with encrypted individual keys and IVs)
+    switch (fileExists) {
+      case ResourceStatus.exist:
+        // Reuse the individual key if the file already exists
+        indKey = await KeyManager.getIndividualKey(fileUrl);
 
-    // final indKeyPath = await getIndKeyPath();
-    // final indKeyUrl = await getFileUrl(indKeyPath);
-    // final indKeyMap = await loadPrvTTL(indKeyUrl);
-    // assert(indKeyMap.containsKey(fileUrl));
+      case ResourceStatus.notExist:
+        // Generate random individual key
+        indKey = genRandIndividualKey();
 
-    // final indKeyIV = IV.fromBase64(indKeyMap![fileUrl][ivPred] as String);
-    // final encIndKeyStr = indKeyMap[fileUrl][sessionKeyPred] as String;
+        // Add the encrypted individual key and its IV to the ind-key file
+        await KeyManager.putIndividualKey(filePath, indKey);
 
-    // indKey = Key.fromBase64(decryptData(encIndKeyStr, masterKey, indKeyIV));
-    indKey = await KeyManager.getIndividualKey(fileUrl);
-  } else if (fileExists == ResourceStatus.notExist) {
-    replace = false;
-    // Generate individual/session key and its IV
+      default:
+        throw Exception('Unable to determine if file "$filePath" exists');
+    }
 
-    indKey = genRandIndividualKey();
-    final indKeyIV = genRandIV();
-    final masterKey = await KeyManager.getMasterKey();
-
-    // Encrypt individual Key
-    final encIndKeyStr = encryptData(indKey.base64, masterKey, indKeyIV);
-
-    // Add the encrypted individual key and its IV to the ind-key file
-    await addIndKey(filePath, encIndKeyStr, indKeyIV);
+    // Encrypt the file content
+    content = await getEncTTLStr(filePath, fileContent, indKey, genRandIV());
   } else {
-    print('Exception: Unable to determine if file "$filePath" exists');
+    content = fileContent;
   }
 
-  // Create file with encrypted data on server
-
-  await createResource(fileUrl,
-      content: await getEncTTLStr(filePath, fileContent, indKey, genRandIV()),
-      replaceIfExist: replace);
+  // Create file on server
+  await createResource(fileUrl, content: content, replaceIfExist: replace);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidpod
 description: Support easy access to data stored on Solid Pod servers.
-version: 0.5.27
+version: 0.5.28
 homepage: https://github.com/anusii/solidpod
 
 environment:


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Support non-encrypted content in readPod() and writePod() as demonstrated in pull request https://github.com/anusii/keypod/pull/103

- Link to associated issue: #160 

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [ ] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [x] Linux
  - [ ] MacOS
  - [ ] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [x] Merge dev into the branch
- [x] Resolve any conflicts
- [x] Add one line summary into CHANGELOG.md
- [x] Bump appropriate version number in pubspec.yaml
- [x] Push to git repository and review
- [x] Merge PR into dev
