### PR TITLE
dc/166 overwrite datafile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ numbers.
 
 ## 0.6 Future Release
 
++ Support the use of the same filename to store encrypted/unencrypted data. [0.5.31]
 + Input security key by pressing the enter key. [0.5.30]
 + Add/Delete corresponding individual keys when adding/deleting data files. [0.5.29]
 + Support the read/write of non-encrypted data file. [0.5.28].

--- a/lib/src/solid/common_func.dart
+++ b/lib/src/solid/common_func.dart
@@ -129,9 +129,7 @@ Future<void> deleteDataFile(String fileName, BuildContext context,
                 actions: [
                   ElevatedButton(
                     onPressed: () async {
-                      await deleteResource(fileUrl, contentType);
-                      await deleteAclForResource(fileUrl);
-                      await KeyManager.removeIndividualKey(filePath);
+                      await deleteFile(filePath, contentType: contentType);
                       Navigator.pop(context);
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(

--- a/lib/src/solid/login.dart
+++ b/lib/src/solid/login.dart
@@ -37,8 +37,6 @@ import 'package:solidpod/src/solid/authenticate.dart';
 import 'package:solidpod/src/widgets/show_animation_dialog.dart';
 import 'package:solidpod/src/screens/initial_setup/initial_setup_screen.dart';
 import 'package:solidpod/src/solid/api/rest_api.dart';
-import 'package:solidpod/src/solid/authenticate.dart';
-import 'package:solidpod/src/widgets/show_animation_dialog.dart';
 
 // TODO 20240515 gjw Eventually remove the show - using for now to support API
 // development.

--- a/lib/src/solid/read_pod.dart
+++ b/lib/src/solid/read_pod.dart
@@ -33,7 +33,6 @@ library;
 import 'package:flutter/material.dart' hide Key;
 
 import 'package:encrypt/encrypt.dart';
-import 'package:path/path.dart' as path;
 
 import 'package:solidpod/src/solid/api/rest_api.dart';
 import 'package:solidpod/src/solid/common_func.dart';

--- a/lib/src/solid/utils/misc.dart
+++ b/lib/src/solid/utils/misc.dart
@@ -386,3 +386,16 @@ Future<void> deleteAclForResource(String resourceUrl) async {
           'Error occurred when checking status of ACL file for "$resourceUrl"');
   }
 }
+
+/// Delete a file with path [filePath], its ACL file, and its encryption key
+/// if exists.
+/// Throws an exception if the file does not exist or any error occurs.
+Future<void> deleteFile(String filePath,
+    {ResourceContentType contentType = ResourceContentType.turtleText}) async {
+  final fileUrl = await getFileUrl(filePath);
+  await deleteResource(fileUrl, contentType);
+  await deleteAclForResource(fileUrl);
+  if (await KeyManager.hasIndividualKey(fileUrl)) {
+    await KeyManager.removeIndividualKey(filePath);
+  }
+}

--- a/lib/src/solid/write_pod.dart
+++ b/lib/src/solid/write_pod.dart
@@ -79,7 +79,7 @@ Future<void> writePod(
     // Delete existing (encrypted) file if the new content is unencrypted
 
     if (await KeyManager.hasIndividualKey(fileUrl)) {
-      await deleteFile(filePath);
+      await deleteDataFile(fileName, context);
     }
 
     content = fileContent;

--- a/lib/src/solid/write_pod.dart
+++ b/lib/src/solid/write_pod.dart
@@ -34,8 +34,6 @@ import 'dart:core';
 
 import 'package:flutter/material.dart' hide Key;
 
-import 'package:encrypt/encrypt.dart';
-
 import 'package:solidpod/src/solid/api/rest_api.dart';
 import 'package:solidpod/src/solid/common_func.dart';
 import 'package:solidpod/src/solid/constants.dart' show ResourceStatus;

--- a/lib/src/solid/write_pod.dart
+++ b/lib/src/solid/write_pod.dart
@@ -108,6 +108,8 @@ Future<void> writePod(
     case ResourceStatus.unknown:
       throw Exception(
           'Unable to determine if file "$filePath" exists, writePod() aborted');
+
+    case ResourceStatus.notExist: // Empty case falls through.
     default:
       debugPrint('File "$filePath" does not exist');
   }

--- a/lib/src/solid/write_pod.dart
+++ b/lib/src/solid/write_pod.dart
@@ -70,7 +70,7 @@ Future<void> writePod(
             '${existingFileEncrypted ? "Encrypted" : "Unencrypted"}'
             ' data file "$fileName" already exists,'
             ' do you want to overwrite it with '
-            '${encrypted ? "encrypted" : "unencrypted"} data?';
+            '${encrypted ? "encrypted" : "unencrypted"} content?';
 
         await showDialog(
             context: context,
@@ -98,15 +98,16 @@ Future<void> writePod(
                 ));
 
         if (!overwrite) {
-          debugPrint('Not overwriting file "$filePath"');
-          return;
+          throw Exception(
+              'Not overwriting file "$filePath", writePod() aborted');
         } else {
           debugPrint('Overwrite file "$filePath"');
         }
       }
 
     case ResourceStatus.unknown:
-      throw Exception('Unable to determine if file "$filePath" exists');
+      throw Exception(
+          'Unable to determine if file "$filePath" exists, writePod() aborted');
     default:
       debugPrint('File "$filePath" does not exist');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidpod
 description: Support easy access to data stored on Solid Pod servers.
-version: 0.5.30
+version: 0.5.31
 homepage: https://github.com/anusii/solidpod
 
 environment:


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Update writePod() to support the use of the same filename for encrypted and unencrypted key-value pairs

- Link to associated issue: https://github.com/anusii/solidpod/issues/166

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [ ] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [x] Linux
  - [ ] MacOS
  - [ ] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [x] Merge dev into the branch
- [x] Resolve any conflicts
- [x] Add one line summary into CHANGELOG.md
- [x] Bump appropriate version number in pubspec.yaml
- [x] Push to git repository and review
- [x] Merge PR into dev
