### PR TITLE
Add app directory as a parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Recorded here are the high level changes for the SolidPod package.
 Guide: Each version update is recorded here with a short user-oriented
 description of the update.
 
+## 0.6.1
+
++ Add app directory name as an optional parameter to the `SolidLogin`
+  function
+
 ## 0.6.0
 
 + Update Readme with prerequisites for `macos` and `web` [0.5.49]

--- a/demopod/lib/main.dart
+++ b/demopod/lib/main.dart
@@ -79,6 +79,7 @@ class DemoPod extends StatelessWidget {
         // DALL-E3.
 
         title: 'SOLID POD DEMONSTRATOR',
+        appDirectory: 'exampleApp',
         image: AssetImage('assets/images/demopod_image.png'),
         logo: AssetImage('assets/images/demopod_logo.png'),
         link: 'https://github.com/anusii/solidpod/blob/main/demopod/README.md',

--- a/lib/src/solid/constants/common.dart
+++ b/lib/src/solid/constants/common.dart
@@ -38,6 +38,9 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 // const int longStrLength = 12;
 
+/// Setup app data directory name
+String appDirName = '';
+
 /// String terms used for files created and used inside a POD.
 
 const String encKeyFile = 'enc-keys.ttl';

--- a/lib/src/solid/login.dart
+++ b/lib/src/solid/login.dart
@@ -43,7 +43,11 @@ import 'package:solidpod/src/solid/api/rest_api.dart';
 // development.
 
 import 'package:solidpod/src/solid/utils/misc.dart'
-    show generateDefaultFiles, generateDefaultFolders, getAppNameVersion;
+    show
+        generateDefaultFiles,
+        generateDefaultFolders,
+        getAppNameVersion,
+        setAppDirName;
 
 // Screen size support functions to identify narrow and very narrow screens. The
 // width dictates whether the Login panel is laid out on the right with the app
@@ -93,6 +97,7 @@ class SolidLogin extends StatefulWidget {
 
     required this.child,
     this.required = true,
+    this.appDirectory = '',
     this.image =
         const AssetImage('assets/images/default_image.jpg', package: 'solid'),
     this.logo =
@@ -166,6 +171,9 @@ class SolidLogin extends StatefulWidget {
 
   final bool required;
 
+  /// Directory name to consider when storing app data
+  final String appDirectory;
+
   @override
   State<SolidLogin> createState() => _SolidLoginState();
 }
@@ -195,6 +203,7 @@ class _SolidLoginState extends State<SolidLogin> {
   // Fetch the package information.
 
   Future<void> _initPackageInfo() async {
+    await setAppDirName(widget.appDirectory);
     final folders = await generateDefaultFolders();
     final files = await generateDefaultFiles();
 

--- a/lib/src/solid/utils/misc.dart
+++ b/lib/src/solid/utils/misc.dart
@@ -187,44 +187,41 @@ Future<String> getEncTTLStr(
 
 /// Returns the path of file with verification key and private key
 Future<String> getEncKeyPath() async =>
-    [await AppInfo.canonicalName, encDir, encKeyFile].join('/');
+    [appDirName, encDir, encKeyFile].join('/');
 
 /// Returns the path of file with individual keys
 Future<String> getIndKeyPath() async =>
-    [await AppInfo.canonicalName, encDir, indKeyFile].join('/');
+    [appDirName, encDir, indKeyFile].join('/');
 
 /// Returns the path of file with public keys
 Future<String> getPubKeyPath() async =>
-    [await AppInfo.canonicalName, sharingDir, pubKeyFile].join('/');
+    [appDirName, sharingDir, pubKeyFile].join('/');
 
 /// Returns the path of public file with individual keys
 Future<String> getPubIndKeyPath() async =>
-    [await AppInfo.canonicalName, sharingDir, pubIndKeyFile].join('/');
+    [appDirName, sharingDir, pubIndKeyFile].join('/');
 
 /// Returns the path of file with individual keys accessed only
 /// by authenticated users
 Future<String> getAuthUserIndKeyPath() async =>
-    [await AppInfo.canonicalName, sharingDir, authUserIndKeyFile].join('/');
+    [appDirName, sharingDir, authUserIndKeyFile].join('/');
 
 /// Returns the path of the data directory
-Future<String> getDataDirPath() async =>
-    [await AppInfo.canonicalName, dataDir].join('/');
+Future<String> getDataDirPath() async => [appDirName, dataDir].join('/');
 
 /// Returns the path of the shared directory
-Future<String> getSharedDirPath() async =>
-    [await AppInfo.canonicalName, sharedDir].join('/');
+Future<String> getSharedDirPath() async => [appDirName, sharedDir].join('/');
 
 /// Returns the path of the shared directory
 Future<String> getSharedKeyFilePath() async =>
-    [await AppInfo.canonicalName, sharedDir, sharedKeyFile].join('/');
+    [appDirName, sharedDir, sharedKeyFile].join('/');
 
 /// Returns the path of the encryption directory
-Future<String> getEncDirPath() async =>
-    [await AppInfo.canonicalName, encDir].join('/');
+Future<String> getEncDirPath() async => [appDirName, encDir].join('/');
 
 /// Returns the path of the encryption directory
 Future<String> getPermLogFilePath() async =>
-    [await AppInfo.canonicalName, logsDir, permLogFile].join('/');
+    [appDirName, logsDir, permLogFile].join('/');
 
 /// Extract the app name and the version from the package info
 /// Return a record (with named fields https://dart.dev/language/records)
@@ -267,16 +264,14 @@ Future<bool> deleteLogIn() async => AuthDataManager.removeAuthData();
 /// Each string in the list represents a path to a default folder for the application.
 
 Future<List<String>> generateDefaultFolders() async {
-  final mainResDir = await AppInfo.canonicalName;
-
-  final dataDirLoc = [mainResDir, dataDir].join('/');
-  final sharingDirLoc = [mainResDir, sharingDir].join('/');
-  final sharedDirLoc = [mainResDir, sharedDir].join('/');
-  final encDirLoc = [mainResDir, encDir].join('/');
-  final logDirLoc = [mainResDir, logsDir].join('/');
+  final dataDirLoc = [appDirName, dataDir].join('/');
+  final sharingDirLoc = [appDirName, sharingDir].join('/');
+  final sharedDirLoc = [appDirName, sharedDir].join('/');
+  final encDirLoc = [appDirName, encDir].join('/');
+  final logDirLoc = [appDirName, logsDir].join('/');
 
   final folders = [
-    mainResDir,
+    appDirName,
     sharingDirLoc,
     sharedDirLoc,
     dataDirLoc,
@@ -292,12 +287,10 @@ Future<List<String>> generateDefaultFolders() async {
 /// Each string in the list represents a path to a default folder for the application.
 
 Future<Map<dynamic, dynamic>> generateDefaultFiles() async {
-  final mainResDir = await AppInfo.canonicalName;
-
-  final sharingDirLoc = [mainResDir, sharingDir].join('/');
-  final sharedDirLoc = [mainResDir, sharedDir].join('/');
-  final encDirLoc = [mainResDir, encDir].join('/');
-  final logDirLoc = [mainResDir, logsDir].join('/');
+  final sharingDirLoc = [appDirName, sharingDir].join('/');
+  final sharedDirLoc = [appDirName, sharedDir].join('/');
+  final encDirLoc = [appDirName, encDir].join('/');
+  final logDirLoc = [appDirName, logsDir].join('/');
 
   final files = {
     sharingDirLoc: [
@@ -312,6 +305,18 @@ Future<Map<dynamic, dynamic>> generateDefaultFiles() async {
     encDirLoc: [encKeyFile, indKeyFile],
   };
   return files;
+}
+
+/// Set directory name for the app for storing the POD data
+///
+/// If not initially set the app name will be taken by default.
+
+Future<void> setAppDirName(String inputAppDirName) async {
+  if (inputAppDirName.isEmpty) {
+    appDirName = await AppInfo.canonicalName;
+  } else {
+    appDirName = inputAppDirName;
+  }
 }
 
 /// Get resource acl file path

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidpod
 description: Support easy access to data stored on Solid Pod servers.
-version: 0.6.0
+version: 0.6.1
 homepage: https://github.com/anusii/solidpod
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: solidpod
-description: Support easy access to data stored on Solid Pod servers.
+description: A library to support easy access to data stored on Pods in Solid servers.
 version: 0.6.1
 homepage: https://github.com/anusii/solidpod
 


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Add app directory as an optional parameter to the SolidLogin function. 

- Link to associated issue: https://github.com/anusii/solidpod/issues/231

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
- [ ] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev
