### PR TITLE
dc/246 refresh fail login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Recorded here are the high level changes for the SolidPod package.
 Guide: Each version update is recorded here with a short user-oriented
 description of the update.
 
+## 0.6.5
+
++ Require log into solid server if refreshing expired access token is failed
++ Update dependencies
+
 ## 0.6.4
 
 + Encrypt large files

--- a/demopod/pubspec.yaml
+++ b/demopod/pubspec.yaml
@@ -10,17 +10,17 @@ environment:
 
 dependencies:
   editable: ^2.0.0
-  file_picker: ^8.1.6
+  file_picker: ^8.1.7
   flutter:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
   intl: ^0.19.0
-  rdflib: ^0.2.10
+  rdflib: ^0.2.11
   solidpod:
     path: ..
   universal_io: ^2.2.2
-  window_manager: ^0.3.7
+  window_manager: ^0.4.3
 
 dev_dependencies:
   # dart_code_metrics:
@@ -29,7 +29,7 @@ dev_dependencies:
   #     ref: dev
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.0
+  flutter_lints: ^5.0.0
 
 flutter:
   uses-material-design: true

--- a/lib/src/solid/authenticate.dart
+++ b/lib/src/solid/authenticate.dart
@@ -74,6 +74,7 @@ Future<List<dynamic>?> solidAuthenticate(
       authData = await AuthDataManager.loadAuthData();
       assert(authData != null);
     } else {
+      debugPrint('solidAuthenticate() => solid_auth.authenticate($serverId)');
       // Authentication process for the POD issuer.
 
       final issuerUri = await getIssuer(serverId);

--- a/lib/src/solid/utils/authdata_manager.dart
+++ b/lib/src/solid/utils/authdata_manager.dart
@@ -124,12 +124,15 @@ class AuthDataManager {
     assert(_logoutUrl != null && _rsaInfo != null && _authResponse != null);
     try {
       final tokenResponse = await _getTokenResponse();
+      if (tokenResponse == null) {
+        throw Exception('Refreshing access token failed');
+      }
       return {
         'client': _authResponse!.client,
         'rsaInfo': _rsaInfo,
         'authResponse': _authResponse,
         'tokenResponse': tokenResponse,
-        'accessToken': tokenResponse!.accessToken,
+        'accessToken': tokenResponse.accessToken,
         'idToken': _authResponse!.idToken,
         'refreshToken': _authResponse!.refreshToken,
         'expiresIn': tokenResponse.expiresIn,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,43 +8,43 @@ environment:
   flutter: '>=1.17.0'
 
 dependencies:
-  crypto: ^3.0.3
+  crypto: ^3.0.6
   encrypt: ^5.0.3
-  fast_rsa: ^3.6.3
+  fast_rsa: ^3.7.1
   flutter:
     sdk: flutter
-  flutter_form_builder: ^9.3.0
-  flutter_secure_storage: ^9.2.2
-  flutter_svg: ^2.0.10+1
-  form_builder_validators: ^11.0.0
-  http: ^1.2.2
+  flutter_form_builder: ^9.7.0
+  flutter_secure_storage: ^9.2.4
+  flutter_svg: ^2.0.17
+  form_builder_validators: ^11.1.1
+  http: ^1.3.0
   intl: ^0.19.0
   jwt_decoder: ^2.0.1
   loading_indicator: ^3.1.1
-  package_info_plus: ^8.0.1
+  package_info_plus: ^8.1.4
   path: ^1.9.0
   pointycastle: ^3.9.1
-  rdflib: ^0.2.10
+  rdflib: ^0.2.11
   solid_auth: ^0.1.22
   # solid_auth:
   #   path: ../solid-auth # Use a local path whilst solid auth is under development.
-  url_launcher: ^6.3.0
+  url_launcher: ^6.3.1
 
 dev_dependencies:
-  build_runner: ^2.4.11
-  custom_lint: ^0.6.4
+  build_runner: ^2.4.14
+  custom_lint: ^0.7.1
   dart_code_metrics:
     git:
       url: https://github.com/anusii/dart-code-metrics.git
       ref: dev
-  flutter_lints: ^4.0.0
+  flutter_lints: ^5.0.0
   flutter_test:
     sdk: flutter
   # Not yet use solid-lints. It requires analyze 6.2.0 and
   # dart-code-metrics fails.
   # solid_lints: ^0.1.1
-  lints: ^4.0.0
-  ubuntu_lints: ^0.4.0
+  lints: ^5.1.1
+  ubuntu_lints: ^0.4.1
 
 # This package supports all platforms listed below.
 platforms:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidpod
 description: A library to support easy access to data stored on Pods in Solid servers.
-version: 0.6.4
+version: 0.6.5
 homepage: https://github.com/anusii/solidpod
 
 environment:


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Require user to log in the solid server if refreshing access token is failed.

- Link to associated issue: #246

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [ ] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [x] Linux
  - [ ] MacOS
  - [x] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [x] Merge dev into the branch
- [x] Resolve any conflicts
- [x] Add one line summary into CHANGELOG.md
- [x] Bump appropriate version number in pubspec.yaml
- [x] Push to git repository and review
- [x] Merge PR into dev
