### PR TITLE
Jess/webid help

### DIFF
--- a/lib/src/solid/constants/common.dart
+++ b/lib/src/solid/constants/common.dart
@@ -67,6 +67,7 @@ const String pubKeyPred = 'pubKey';
 const String encKeyPred = 'encKey'; // verification key of the master key
 const String pathPred = 'path';
 const String accessListPred = 'accessList';
+const String authUserPred = 'authUserList';
 const String sharedKeyPred = 'sharedKey';
 const String sessionKeyPred = 'sessionKey';
 const String encDataPred = 'encData';

--- a/lib/src/solid/constants/ui.dart
+++ b/lib/src/solid/constants/ui.dart
@@ -198,3 +198,15 @@ class ScrollbarLayout {
 
 /// Normal height for data loading screens
 const double normalLoadingScreenHeight = 200.0;
+
+/// Colours used across dropdown dialogs and prompts.
+
+class DropdownColors {
+  /// Primary colour (Forest Green) used for dropdown elements
+
+  static const primary = Color(0xFF2E7D32);
+
+  /// Accent colour (Lighter Green) used for dividers and secondary elements.
+
+  static const accent = Color(0xFF4CAF50);
+}

--- a/lib/src/solid/constants/ui.dart
+++ b/lib/src/solid/constants/ui.dart
@@ -24,7 +24,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 ///
-/// Authors: Ashley Tang
+/// Authors: Ashley Tang, Jess Moore
 
 library;
 
@@ -195,3 +195,6 @@ class ScrollbarLayout {
   ///
   static const horizontalGap = SizedBox(width: 10);
 }
+
+/// Normal height for data loading screens
+const double normalLoadingScreenHeight = 200.0;

--- a/lib/src/solid/constants/ui.dart
+++ b/lib/src/solid/constants/ui.dart
@@ -210,3 +210,31 @@ class DropdownColors {
 
   static const accent = Color(0xFF4CAF50);
 }
+
+/// Layout constants used for WebId dialogs
+
+class WebIdLayout {
+  /// Vertical gap between paragraphs
+
+  static const paraVertGap = SizedBox(height: 10);
+
+  /// Standard padding for dialog content.
+
+  static const contentPadding = EdgeInsets.symmetric(horizontal: 50);
+
+  /// Standard width for security dialogs.
+
+  static const dialogWidth = 480.0;
+
+  /// Height of dropdown suggestion box.
+
+  static const dropdownHeight = 120.0;
+
+  /// Elevation of dropdown suggestion cards.
+
+  static double dropdownElevation = 5;
+
+  /// Padding of dropdown suggestion list.
+
+  static const listPadding = EdgeInsets.fromLTRB(0, 5, 0, 5);
+}

--- a/lib/src/solid/get_access_lists.dart
+++ b/lib/src/solid/get_access_lists.dart
@@ -1,0 +1,80 @@
+/// Function to get access list for each file in a list of files in a POD.
+///
+// Time-stamp: <Sunday 2025-07-27 10:59:10 +1100 Jess Moore>
+///
+/// Copyright (C) 2024-2025, Software Innovation Institute, ANU.
+///
+/// Licensed under the MIT License (the "License").
+///
+/// License: https://choosealicense.com/licenses/mit/.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+///
+/// Authors: Jess Moore
+
+// ignore_for_file: use_build_context_synchronously
+
+library;
+
+import 'package:flutter/material.dart' hide Key;
+
+import 'package:solidpod/src/solid/constants/common.dart';
+import 'package:solidpod/src/solid/read_permission.dart';
+
+/// Get the access control list data of each file in a map of files, ie. webIDs and
+/// their access permission for each of the files in a map of data files [dataMap].
+/// Parameters:
+///   [dataMap] is map of resource data to which access lists are added.
+///   [child] is the child widget to return to
+///   [fileFlag] set to true if the resource is a file, false if the resource is a directory.
+///   [isFilePath] Set to true if the filename provided is the full path.
+///   [fileList] Provide list of files in Pods if known.
+Future<Map<String, dynamic>> getAccessLists(
+  Map<String, dynamic> dataMap,
+  BuildContext context,
+  Widget child, {
+  bool fileFlag = true,
+  bool isFilePath = true,
+  List<String>? fileList,
+}) async {
+  fileList = fileList ?? dataMap.keys.toList();
+
+  // Read recipients for each file
+  for (final fileName in fileList) {
+    // 20250726 jm: While not an external file, as the file
+    // is a full file path, use isExternalRes true, to avoid
+    // readPermission() prepending the filepath.
+    final dynamic permList = await readPermission(
+      fileName,
+      fileFlag,
+      context,
+      child,
+      isExternalRes: true,
+    );
+    // Create empty map for each file if dataMap lacks file data
+    if (!dataMap.containsKey(fileName)) {
+      dataMap[fileName] = {};
+    }
+
+    // Add recipients map to dataMap
+    dataMap[fileName][authUserPred] = permList;
+  }
+
+  return dataMap;
+}

--- a/lib/src/solid/get_recipient_list.dart
+++ b/lib/src/solid/get_recipient_list.dart
@@ -53,10 +53,6 @@ Future<List<String>> getRecipientList(
   // Initialise the resource list and data
   final List<String> fileList;
   final dataMap = <String, dynamic>{};
-
-  // Initialise webID list
-  final webIdList = <String>[];
-  final List<String> uniqWebIdList;
   final Map<String, dynamic> tempMap;
 
   try {
@@ -72,22 +68,9 @@ Future<List<String>> getRecipientList(
         fileList: fileList,
       );
 
-      // Extract webIDs to list
-      for (final fileName in fileList) {
-        tempMap[fileName][authUserPred].keys.forEach((key) {
-          webIdList.add(key.toString());
-        });
-      }
-
-      // Derive unique WebIds
-      uniqWebIdList = webIdList.toSet().toList();
-      // debugPrint('Unique webIDs: $uniqWebIdList');
-
-      // Recipients = unique WebIds minus user
-      final uniqRecipWebIdList = uniqWebIdList;
-      uniqRecipWebIdList.removeAt(0);
-
-      // debugPrint('Unique webIDs (excl user): $uniqRecipWebIdList');
+      // Extract recipient webIDs to list
+      final uniqRecipWebIdList =
+          extractRecipWebIdList(tempMap, fileList: fileList);
 
       return uniqRecipWebIdList;
     } else {
@@ -99,4 +82,45 @@ Future<List<String>> getRecipientList(
     debugPrint(e.toString());
     rethrow;
   }
+}
+
+/// Extract the list of unique WebIds of recipients of the Pod user's
+/// files from the [dataFilesMap] containing acccess control lists for
+/// each file in the app data folder of the user's Pod.
+/// Where the first webId, on the unique WebId list aggregated
+/// across all their files, is assumed to be the user.
+///
+/// Parameters:
+///   [dataFilesMap] is the map of file names and access data.
+///   [fileList] is the list of files in the [dataFilesMap].
+List<String> extractRecipWebIdList(
+  Map<String, dynamic> dataFilesMap, {
+  List<String>? fileList,
+}) {
+  // Initialise webID list
+  final webIdList = <String>[];
+  final List<String> uniqWebIdList;
+
+  // If not supplied, extract fileList
+  fileList ??= dataFilesMap.keys.toList();
+
+  // Extract webIDs to list
+  for (final fileName in fileList) {
+    dataFilesMap[fileName][authUserPred].keys.forEach((key) {
+      webIdList.add(key.toString());
+    });
+  }
+
+  // Derive unique WebIds
+  uniqWebIdList = webIdList.toSet().toList();
+  // debugPrint('Unique webIDs: $uniqWebIdList');
+
+  // Recipients = unique WebIds minus user
+  // Assumes the first WebId is the user
+  final uniqRecipWebIdList = uniqWebIdList;
+  uniqRecipWebIdList.removeAt(0);
+
+  // debugPrint('Unique webIDs (excl user): $uniqRecipWebIdList');
+
+  return uniqRecipWebIdList;
 }

--- a/lib/src/solid/get_recipient_list.dart
+++ b/lib/src/solid/get_recipient_list.dart
@@ -1,0 +1,102 @@
+/// Function that gets access list for each file in a list of files in a POD and returns the list of unique webIDs of authorized users, excluding the POD owner.
+///
+// Time-stamp: <Monday 2025-07-28 15:38:10 +1100 Jess Moore>
+///
+/// Copyright (C) 2024-2025, Software Innovation Institute, ANU.
+///
+/// Licensed under the MIT License (the "License").
+///
+/// License: https://choosealicense.com/licenses/mit/.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+///
+/// Authors: Jess Moore
+
+// ignore_for_file: use_build_context_synchronously
+
+library;
+
+import 'package:flutter/material.dart' hide Key;
+
+import 'package:solidpod/src/solid/constants/common.dart';
+import 'package:solidpod/src/solid/get_access_lists.dart';
+import 'package:solidpod/src/solid/get_resources.dart';
+
+/// Retrieve the list of files and access control lists on each file in the user's POD
+/// to find the list of unique WebIds of recipients of the user's files.
+/// Parameters:
+///   [child] is the child widget to return to
+///   [fileFlag] set to true if the resource is a file, false if the resource is a directory.
+///   [isFilePath] Set to true if the filename provided is the full path
+Future<List<String>> getRecipientList(
+  BuildContext context,
+  Widget child, {
+  bool fileFlag = true,
+  bool isFilePath = true,
+}) async {
+  // Initialise the resource list and data
+  final List<String> fileList;
+  final dataMap = <String, dynamic>{};
+
+  // Initialise webID list
+  final webIdList = <String>[];
+  final List<String> uniqWebIdList;
+  final Map<String, dynamic> tempMap;
+
+  try {
+    // Get file list
+    fileList = await getResources(context, child);
+
+    if (fileList.isNotEmpty) {
+      // Retrieve ACLs for each file
+      tempMap = await getAccessLists(
+        dataMap,
+        context,
+        child,
+        fileList: fileList,
+      );
+
+      // Extract webIDs to list
+      for (final fileName in fileList) {
+        tempMap[fileName][authUserPred].keys.forEach((key) {
+          webIdList.add(key.toString());
+        });
+      }
+
+      // Derive unique WebIds
+      uniqWebIdList = webIdList.toSet().toList();
+      // debugPrint('Unique webIDs: $uniqWebIdList');
+
+      // Recipients = unique WebIds minus user
+      final uniqRecipWebIdList = uniqWebIdList;
+      uniqRecipWebIdList.removeAt(0);
+
+      // debugPrint('Unique webIDs (excl user): $uniqRecipWebIdList');
+
+      return uniqRecipWebIdList;
+    } else {
+      // No files found in user's POD, therefore no recipients
+      // of the user's files.
+      return [];
+    }
+  } on Object catch (e) {
+    debugPrint(e.toString());
+    rethrow;
+  }
+}

--- a/lib/src/solid/get_resources.dart
+++ b/lib/src/solid/get_resources.dart
@@ -1,0 +1,97 @@
+/// Function to get POD resources by reading each private file in PODs.
+///
+// Time-stamp: <Sunday 2025-07-27 10:59:10 +1100 Jess Moore>
+///
+/// Copyright (C) 2024-2025, Software Innovation Institute, ANU.
+///
+/// Licensed under the MIT License (the "License").
+///
+/// License: https://choosealicense.com/licenses/mit/.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+///
+/// Authors: Jess Moore, Anushka Vidanage, Graham Williams
+
+// ignore_for_file: use_build_context_synchronously
+
+library;
+
+import 'package:flutter/material.dart' hide Key;
+
+import 'package:solidpod/src/solid/api/rest_api.dart';
+import 'package:solidpod/src/solid/common_func.dart';
+import 'package:solidpod/src/solid/constants/common.dart';
+import 'package:solidpod/src/solid/utils/misc.dart';
+
+/// Get the list of files created by the user in their POD by querying the data directory of the POD.
+///
+/// We first check if the user is logged in and get the list of resources in the container.
+///
+/// Examples:
+/// - `getResources('appname/data')` reads from `appname/data` directory.
+///
+/// Note: Only `appname/data/` paths are supported for the readPod operations called by getResources().
+
+Future<List<String>> getResources(
+  BuildContext context,
+  Widget child,
+) async {
+  final loggedIn = await loginIfRequired(context);
+  var webId = await getWebId() as String;
+  webId = webId.replaceAll(profCard, '');
+
+  if (loggedIn) {
+    final dataDirPath = await getDataDirPath();
+    final dataDirUrl = await getDirUrl(dataDirPath);
+
+    // Why do we need the additional `/`? (20250714 gjw)
+
+    final resDirUrl = '$dataDirUrl/';
+
+    // Normalise the file path to use appname/data as base path
+    // and handle cross-platform path separators properly.
+
+    final normalizedFilePath = await normalizeFilePath(resDirUrl, null);
+
+    // Check if the directory exists.
+
+    final dirExists = await checkResourceStatus(resDirUrl, fileFlag: false);
+
+    switch (dirExists) {
+      case ResourceStatus.exist:
+        try {
+          //debugPrint('Data: $dataDirUrl');
+          final res = await getResourcesInContainer(resDirUrl);
+          // debugPrint(res.toString());
+
+          return res.files;
+        } on Object catch (e) {
+          debugPrint(e.toString());
+          rethrow;
+        }
+      case ResourceStatus.notExist:
+        throw Exception('Resource "$normalizedFilePath" does not exist.');
+      default:
+        throw Exception('Unknown error.');
+    }
+  } else {
+    debugPrint('WARN: Not logged in when finding the list of resources.');
+    return [];
+  }
+}

--- a/lib/src/solid/grant_permission_ui.dart
+++ b/lib/src/solid/grant_permission_ui.dart
@@ -743,7 +743,7 @@ class GrantPermissionUiState extends State<GrantPermissionUi>
               return _buildPermPage(context, snapshot.data);
             }
           } else {
-            return Scaffold(body: loadingScreen(200));
+            return Scaffold(body: loadingScreen(normalLoadingScreenHeight));
           }
         },
       );

--- a/lib/src/solid/grant_permission_ui.dart
+++ b/lib/src/solid/grant_permission_ui.dart
@@ -61,6 +61,7 @@ class GrantPermissionUi extends StatefulWidget {
     this.recipientList = const ['public', 'indi', 'auth', 'group'],
     this.externalWebId,
     this.fileName,
+    this.dataFilesMap = const {},
     this.customAppBar,
     super.key,
   });
@@ -98,6 +99,13 @@ class GrantPermissionUi extends StatefulWidget {
   /// If [isExternalRes] is set to true this must be set and the value should
   /// be the url of the resource
   final String? fileName;
+
+  /// Map of data files on a user's POD used to extract the
+  /// user's recipient list by the WebIdTextInputScreen.
+  /// If not provided, the WebIdTextInputScreen will read the
+  /// user's files in their app data folder on their Pod to
+  /// fetch the ACLs needed to derive the user's recipient list.
+  final Map<String, dynamic> dataFilesMap;
 
   /// App specific app bar
   final PreferredSizeWidget? customAppBar;
@@ -522,6 +530,7 @@ class GrantPermissionUiState extends State<GrantPermissionUi>
                                             await indWebIdInputDialog(
                                               context,
                                               _updateIndWebIdInput,
+                                              widget.dataFilesMap,
                                             );
                                           },
                                           child: Text(

--- a/lib/src/solid/popup_login.dart
+++ b/lib/src/solid/popup_login.dart
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 ///
-/// Authors: Kevin Wang
+/// Authors: Kevin Wang, Jess Moore
 
 library;
 
@@ -21,6 +21,7 @@ import 'package:flutter/material.dart';
 
 import 'package:solidpod/src/solid/authenticate.dart';
 import 'package:solidpod/src/solid/common_func.dart' show initPodsIfRequired;
+import 'package:solidpod/src/solid/constants/ui.dart';
 import 'package:solidpod/src/widgets/loading_screen.dart';
 
 /// A widget to pop up the login prompt if the user is not logged in
@@ -69,7 +70,7 @@ class _SolidPopupLoginState extends State<SolidPopupLogin> {
           if (snapshot.connectionState == ConnectionState.done) {
             return _loadedScreen(snapshot.data!);
           }
-          return loadingScreen(200);
+          return loadingScreen(normalLoadingScreenHeight);
         },
       ),
     );

--- a/lib/src/solid/shared_resources_ui.dart
+++ b/lib/src/solid/shared_resources_ui.dart
@@ -28,6 +28,7 @@ library;
 
 import 'package:flutter/material.dart';
 
+import 'package:solidpod/src/solid/constants/ui.dart';
 import 'package:solidpod/src/solid/shared_resources.dart';
 import 'package:solidpod/src/solid/solid_func_call_status.dart';
 import 'package:solidpod/src/solid/utils/authdata_manager.dart';
@@ -181,7 +182,7 @@ class SharedResourcesUiState extends State<SharedResourcesUi>
             return _buildSharedResourcePage(context, snapshot.data);
           }
         } else {
-          return Scaffold(body: loadingScreen(200));
+          return Scaffold(body: loadingScreen(normalLoadingScreenHeight));
         }
       },
     );

--- a/lib/src/solid/utils/is_phone.dart
+++ b/lib/src/solid/utils/is_phone.dart
@@ -1,0 +1,44 @@
+/// Check if we are running a desktop (and not a browser).
+///
+// Time-stamp: <Saturday 2025-08-02 21:01:01 +1000 Jess Moore>
+///
+/// Copyright (C) 2024, Software Innovation Institute, ANU.
+///
+/// Licensed under the GNU General Public License, Version 3 (the "License").
+///
+/// License: https://www.gnu.org/licenses/gpl-3.0.en.html.
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+/// Authors: Jess Moore
+
+library;
+
+import 'package:flutter/material.dart';
+
+import 'package:universal_io/io.dart' show Platform;
+
+/// Checks the platform type to determine whether running on
+/// a mobile device.
+bool isPhone() {
+  /// Returns true if running on iOS or Android
+
+  if (Platform.isIOS || Platform.isAndroid) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+// coverage:ignore-end

--- a/lib/src/widgets/ind_webid_input_dialog.dart
+++ b/lib/src/widgets/ind_webid_input_dialog.dart
@@ -83,7 +83,6 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
   @override
   void initState() {
     webIdList = widget.uniqRecipWebIdList ?? [];
-    debugPrint('INSIDE WEBID INPUT DIALOG initState()');
     super.initState();
   }
 
@@ -293,12 +292,14 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
 Future<dynamic> indWebIdInputDialog(
   BuildContext context,
   Function onSubmitFunction,
+  Map<String, dynamic> dataFilesMap,
 ) {
   return showDialog(
     context: context,
     builder: (context) {
       return IndWebIdInputScreen(
         onSubmitFunction: onSubmitFunction,
+        dataFilesMap: dataFilesMap,
       );
     },
   );

--- a/lib/src/widgets/ind_webid_input_dialog.dart
+++ b/lib/src/widgets/ind_webid_input_dialog.dart
@@ -32,6 +32,7 @@ import 'package:solidpod/src/solid/api/rest_api.dart';
 import 'package:solidpod/src/solid/constants/common.dart';
 import 'package:solidpod/src/solid/constants/ui.dart';
 import 'package:solidpod/src/solid/utils/alert.dart';
+import 'package:solidpod/src/solid/utils/is_phone.dart';
 import 'package:solidpod/src/widgets/ind_webid_input_screen.dart';
 
 /// A [StatefulWidget] dialog for adding an individual webId.
@@ -138,7 +139,8 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
       insetPadding: WebIdLayout.contentPadding,
       title: const Text('WebID of the individual recipient'),
       content: SizedBox(
-        // width: WebIdLayout.dialogWidth,
+        // Use full width on phones, else use a preset narrower width
+        width: (!isPhone()) ? WebIdLayout.dialogWidth : double.maxFinite,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/src/widgets/ind_webid_input_dialog.dart
+++ b/lib/src/widgets/ind_webid_input_dialog.dart
@@ -134,15 +134,11 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
 
   @override
   Widget build(BuildContext context) {
-    debugPrint('Dialog width: ${MediaQuery.of(context).size.width}');
-    debugPrint('Dialog heigth: ${MediaQuery.of(context).size.height}');
-
     return AlertDialog(
-      insetPadding: const EdgeInsets.symmetric(horizontal: 50),
+      insetPadding: WebIdLayout.contentPadding,
       title: const Text('WebID of the individual recipient'),
       content: SizedBox(
-        height: 400,
-        width: 500, // or double.maxFinite
+        // width: WebIdLayout.dialogWidth,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -153,7 +149,7 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
             ),
             // Show an example WebId that remains visible once user is typing
             const Text('Eg: $demoWebID'),
-            const SizedBox(height: 10),
+            WebIdLayout.paraVertGap,
             const Text('Type their WebId or select a recently used WebId.'),
             const SizedBox(height: 20),
             // Web ID text field
@@ -174,7 +170,8 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
                 filterSuggestions(value);
               }),
             ),
-            const SizedBox(height: 10),
+            // const SizedBox(height: 10),
+            WebIdLayout.paraVertGap,
             if (webIdList.isNotEmpty) ...[
               if (suggestionList.isNotEmpty ||
                   formControllerWebId.text.isNotEmpty) ...[
@@ -191,7 +188,6 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
         TextButton(
           onPressed: () async {
             final receiverWebId = formControllerWebId.text.trim();
-            debugPrint('Submitted: receiverWebId for onSubmit checks');
 
             // User has entered WebId text that satisfies error checks
             if (receiverWebId.isNotEmpty && _helpText == null) {
@@ -241,20 +237,15 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
   }
 
   SizedBox boxedSuggestionList(BuildContext context, List<String> idList) {
-    debugPrint('Suggestions width: ${MediaQuery.of(context).size.width * 0.6}');
-    debugPrint('Suggestions height: 120');
-
     return SizedBox(
-      // width: MediaQuery.of(context).size.width * 0.6, // or double.
-      // maxFinite
       width: double.maxFinite,
-      height: 120,
+      height: WebIdLayout.dropdownHeight,
       child: ListView.builder(
-        padding: const EdgeInsets.fromLTRB(0, 5, 0, 5),
+        padding: WebIdLayout.listPadding,
         itemCount: idList.length,
         itemBuilder: (context, index) {
           return Card(
-            elevation: 5,
+            elevation: WebIdLayout.dropdownElevation,
             child: ListTile(
               title: Text(idList[index]),
               focusColor: SecurityColors.primary,

--- a/lib/src/widgets/ind_webid_input_dialog.dart
+++ b/lib/src/widgets/ind_webid_input_dialog.dart
@@ -127,8 +127,9 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
       setState(() {});
       return;
     }
-    suggestionList =
-        webIdList.where((e) => e.contains(value.toLowerCase())).toList();
+    suggestionList = webIdList
+        .where((e) => e.toLowerCase().contains(value.toLowerCase()))
+        .toList();
 
     setState(() {});
   }

--- a/lib/src/widgets/ind_webid_input_dialog.dart
+++ b/lib/src/widgets/ind_webid_input_dialog.dart
@@ -246,7 +246,7 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
       width: MediaQuery.of(context).size.width * 0.6, // or double.maxFinite
       height: 120,
       child: ListView.builder(
-        padding: const EdgeInsets.all(10),
+        padding: const EdgeInsets.fromLTRB(0, 5, 0, 5),
         itemCount: idList.length,
         itemBuilder: (context, index) {
           return Card(

--- a/lib/src/widgets/ind_webid_input_dialog.dart
+++ b/lib/src/widgets/ind_webid_input_dialog.dart
@@ -31,21 +31,28 @@ import 'package:flutter/material.dart';
 import 'package:solidpod/src/solid/api/rest_api.dart';
 import 'package:solidpod/src/solid/constants/common.dart';
 import 'package:solidpod/src/solid/utils/alert.dart';
+import 'package:solidpod/src/widgets/ind_webid_input_screen.dart';
 
 /// A [StatefulWidget] dialog for adding an individual webId.
-/// Function call requires the following inputs
-/// [onSubmitFunction] is the function to be called on submit
+/// Function call requires the following inputs.
+/// [onSubmitFunction] is the function to be called on submit.
+/// [webIdList] is a list of the webIds of unique recipients of the
+/// owner's data.
 ///
 class IndWebIdTextInput extends StatefulWidget {
   /// Initialise widget variables.
 
   const IndWebIdTextInput({
     required this.onSubmitFunction,
+    this.uniqRecipWebIdList,
     super.key,
   });
 
   /// Function run on Submit button press.
   final Function onSubmitFunction;
+
+  /// List of unique recipient webIds
+  final List<String>? uniqRecipWebIdList;
 
   @override
   State<IndWebIdTextInput> createState() => _IndWebIdTextInputState();
@@ -193,7 +200,9 @@ Future<dynamic> indWebIdInputDialog(
   return showDialog(
     context: context,
     builder: (context) {
-      return IndWebIdTextInput(onSubmitFunction: onSubmitFunction);
+      return IndWebIdInputScreen(
+        onSubmitFunction: onSubmitFunction,
+      );
     },
   );
 }

--- a/lib/src/widgets/ind_webid_input_dialog.dart
+++ b/lib/src/widgets/ind_webid_input_dialog.dart
@@ -134,6 +134,9 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
 
   @override
   Widget build(BuildContext context) {
+    debugPrint('Dialog width: ${MediaQuery.of(context).size.width}');
+    debugPrint('Dialog heigth: ${MediaQuery.of(context).size.height}');
+
     return AlertDialog(
       insetPadding: const EdgeInsets.symmetric(horizontal: 50),
       title: const Text('WebID of the individual recipient'),
@@ -177,29 +180,6 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
                 boxedSuggestionList(context, suggestionList),
               ] else ...[
                 boxedSuggestionList(context, webIdList),
-                // SizedBox(
-                //   width: MediaQuery.of(context).size.width *
-                //       0.6, // or double.maxFinite
-                //   height: 120,
-                //   child: ListView.separated(
-                //     padding: const EdgeInsets.all(10),
-                //     itemCount: webIdList.length,
-                //     separatorBuilder: (context, index) => const Divider(),
-                //     itemBuilder: (context, index) {
-                //       return ListTile(
-                //         title: Text(webIdList[index]),
-                //         hoverColor: DropdownColors.accent,
-                //         splashColor: DropdownColors.primary,
-                //         onTap: () => setState(() {
-                //           // User has started entering text
-                //           _textEntered = true;
-                //           formControllerWebId.text = webIdList[index];
-                //         }),
-                //       );
-                //     },
-                //   ),
-                //   // ),
-                // ),
               ],
             ],
           ],
@@ -259,24 +239,29 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
   }
 
   SizedBox boxedSuggestionList(BuildContext context, List<String> idList) {
+    debugPrint('Suggestions width: ${MediaQuery.of(context).size.width}');
+    debugPrint('Suggestions height: ${MediaQuery.of(context).size.height}');
+
     return SizedBox(
       width: MediaQuery.of(context).size.width * 0.6, // or double.maxFinite
       height: 120,
-      child: ListView.separated(
+      child: ListView.builder(
         padding: const EdgeInsets.all(10),
         itemCount: idList.length,
-        separatorBuilder: (context, index) => const Divider(),
         itemBuilder: (context, index) {
-          return ListTile(
-            title: Text(idList[index]),
-            focusColor: SecurityColors.primary,
-            hoverColor: DropdownColors.accent,
-            splashColor: DropdownColors.primary,
-            onTap: () => setState(() {
-              // User has started entering text
-              _textEntered = true;
-              formControllerWebId.text = idList[index];
-            }),
+          return Card(
+            elevation: 5,
+            child: ListTile(
+              title: Text(idList[index]),
+              focusColor: SecurityColors.primary,
+              hoverColor: DropdownColors.accent,
+              splashColor: DropdownColors.primary,
+              onTap: () => setState(() {
+                // User has started entering text
+                _textEntered = true;
+                formControllerWebId.text = idList[index];
+              }),
+            ),
           );
         },
       ),

--- a/lib/src/widgets/ind_webid_input_dialog.dart
+++ b/lib/src/widgets/ind_webid_input_dialog.dart
@@ -141,8 +141,8 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
       insetPadding: const EdgeInsets.symmetric(horizontal: 50),
       title: const Text('WebID of the individual recipient'),
       content: SizedBox(
-        height: MediaQuery.of(context).size.width * 0.6,
-        width: MediaQuery.of(context).size.width * 0.8, // or double.maxFinite
+        height: 400,
+        width: 500, // or double.maxFinite
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -153,6 +153,8 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
             ),
             // Show an example WebId that remains visible once user is typing
             const Text('Eg: $demoWebID'),
+            const SizedBox(height: 10),
+            const Text('Type their WebId or select a recently used WebId.'),
             const SizedBox(height: 20),
             // Web ID text field
             TextFormField(
@@ -239,11 +241,13 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
   }
 
   SizedBox boxedSuggestionList(BuildContext context, List<String> idList) {
-    debugPrint('Suggestions width: ${MediaQuery.of(context).size.width}');
-    debugPrint('Suggestions height: ${MediaQuery.of(context).size.height}');
+    debugPrint('Suggestions width: ${MediaQuery.of(context).size.width * 0.6}');
+    debugPrint('Suggestions height: 120');
 
     return SizedBox(
-      width: MediaQuery.of(context).size.width * 0.6, // or double.maxFinite
+      // width: MediaQuery.of(context).size.width * 0.6, // or double.
+      // maxFinite
+      width: double.maxFinite,
       height: 120,
       child: ListView.builder(
         padding: const EdgeInsets.fromLTRB(0, 5, 0, 5),

--- a/lib/src/widgets/ind_webid_input_dialog.dart
+++ b/lib/src/widgets/ind_webid_input_dialog.dart
@@ -30,13 +30,14 @@ import 'package:flutter/material.dart';
 
 import 'package:solidpod/src/solid/api/rest_api.dart';
 import 'package:solidpod/src/solid/constants/common.dart';
+import 'package:solidpod/src/solid/constants/ui.dart';
 import 'package:solidpod/src/solid/utils/alert.dart';
 import 'package:solidpod/src/widgets/ind_webid_input_screen.dart';
 
 /// A [StatefulWidget] dialog for adding an individual webId.
 /// Function call requires the following inputs.
 /// [onSubmitFunction] is the function to be called on submit.
-/// [webIdList] is a list of the webIds of unique recipients of the
+/// [uniqRecipWebIdList] is a list of the webIds of unique recipients of the
 /// owner's data.
 ///
 class IndWebIdTextInput extends StatefulWidget {
@@ -65,11 +66,25 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
   /// Capture whether user has started to enter text
   bool _textEntered = false;
 
+  /// WebId list
+  List<String> webIdList = [];
+
+  /// Initialise the matching suggestions list
+  List<String> suggestionList = [];
+  String hint = '';
+
   // dispose text controller when the widget is unmounted
   @override
   void dispose() {
     formControllerWebId.dispose();
     super.dispose();
+  }
+
+  @override
+  void initState() {
+    webIdList = widget.uniqRecipWebIdList ?? [];
+    debugPrint('INSIDE WEBID INPUT DIALOG initState()');
+    super.initState();
   }
 
   /// Generate advice to help user enter valid WebID
@@ -103,43 +118,121 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
     return null;
   }
 
+  /// Generate suggestions for users based on input matches to
+  /// current complete recipient list of user
+  void filterSuggestions(String value) {
+    suggestionList.clear();
+
+    if (value.isEmpty) {
+      setState(() {});
+      return;
+    }
+    suggestionList =
+        webIdList.where((e) => e.contains(value.toLowerCase())).toList();
+
+    setState(() {});
+  }
+
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
       insetPadding: const EdgeInsets.symmetric(horizontal: 50),
       title: const Text('WebID of the individual recipient'),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          // Provide info on what a WebId is
-          const Text(
-            whatIsWebID,
-          ),
-          // Show an example WebId that remains visible once user is typing
-          const Text('Eg: $demoWebID'),
-          const SizedBox(height: 20),
-          // Web ID text field
-          TextFormField(
-            controller: formControllerWebId,
-            decoration: InputDecoration(
-              labelText: 'Individual\'s webID',
-              // Once user has started entering text, use formfield
-              // error message to advise user how to specify
-              // valid webId
-              errorText: _textEntered ? _helpText : null,
+      content: SizedBox(
+        height: MediaQuery.of(context).size.width * 0.6,
+        width: MediaQuery.of(context).size.width * 0.8, // or double.maxFinite
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Provide info on what a WebId is
+            const Text(
+              whatIsWebID,
             ),
-            onChanged: (_) => setState(() {
-              // User has started entering text
-              _textEntered = true;
-            }),
-          ),
-        ],
+            // Show an example WebId that remains visible once user is typing
+            const Text('Eg: $demoWebID'),
+            const SizedBox(height: 20),
+            // Web ID text field
+            TextFormField(
+              controller: formControllerWebId,
+              decoration: InputDecoration(
+                labelText: 'Individual\'s webID',
+                // Once user has started entering text, use formfield
+                // error message to advise user how to specify
+                // valid webId
+                errorText: _textEntered ? _helpText : null,
+              ),
+              onFieldSubmitted: (value) {},
+              onChanged: (value) => setState(() {
+                // User has started entering text
+                _textEntered = true;
+                // Filter suggestions
+                filterSuggestions(value);
+              }),
+            ),
+            const SizedBox(height: 10),
+            if (webIdList.isNotEmpty) ...[
+              if (suggestionList.isNotEmpty ||
+                  formControllerWebId.text.isNotEmpty) ...[
+                // 20250729 jm: Wrap ListView() in fixed SizeBox() to avoid render problems in AlertDialog()
+                SizedBox(
+                  width: MediaQuery.of(context).size.width *
+                      0.6, // or double.maxFinite
+                  height: 120,
+                  child: ListView.separated(
+                    padding: const EdgeInsets.all(10),
+                    itemCount: suggestionList.length,
+                    separatorBuilder: (context, index) => const Divider(),
+                    itemBuilder: (context, index) {
+                      return ListTile(
+                        title: Text(suggestionList[index]),
+                        focusColor: SecurityColors.primary,
+                        hoverColor: DropdownColors.accent,
+                        splashColor: DropdownColors.primary,
+                        onTap: () => setState(() {
+                          // User has started entering text
+                          _textEntered = true;
+                          formControllerWebId.text = suggestionList[index];
+                        }),
+                      );
+                    },
+                  ),
+                  // ),
+                ),
+              ] else ...[
+                SizedBox(
+                  width: MediaQuery.of(context).size.width *
+                      0.6, // or double.maxFinite
+                  height: 120,
+                  child: ListView.separated(
+                    padding: const EdgeInsets.all(10),
+                    itemCount: webIdList.length,
+                    separatorBuilder: (context, index) => const Divider(),
+                    itemBuilder: (context, index) {
+                      return ListTile(
+                        title: Text(webIdList[index]),
+                        hoverColor: DropdownColors.accent,
+                        splashColor: DropdownColors.primary,
+                        onTap: () => setState(() {
+                          // User has started entering text
+                          _textEntered = true;
+                          formControllerWebId.text = webIdList[index];
+                        }),
+                      );
+                    },
+                  ),
+                  // ),
+                ),
+              ],
+            ],
+          ],
+        ),
       ),
       actions: <Widget>[
         TextButton(
           onPressed: () async {
             final receiverWebId = formControllerWebId.text.trim();
+            debugPrint('Submitted: receiverWebId for onSubmit checks');
 
             // User has entered WebId text that satisfies error checks
             if (receiverWebId.isNotEmpty && _helpText == null) {

--- a/lib/src/widgets/ind_webid_input_dialog.dart
+++ b/lib/src/widgets/ind_webid_input_dialog.dart
@@ -175,54 +175,32 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
               if (suggestionList.isNotEmpty ||
                   formControllerWebId.text.isNotEmpty) ...[
                 // 20250729 jm: Wrap ListView() in fixed SizeBox() to avoid render problems in AlertDialog()
-                SizedBox(
-                  width: MediaQuery.of(context).size.width *
-                      0.6, // or double.maxFinite
-                  height: 120,
-                  child: ListView.separated(
-                    padding: const EdgeInsets.all(10),
-                    itemCount: suggestionList.length,
-                    separatorBuilder: (context, index) => const Divider(),
-                    itemBuilder: (context, index) {
-                      return ListTile(
-                        title: Text(suggestionList[index]),
-                        focusColor: SecurityColors.primary,
-                        hoverColor: DropdownColors.accent,
-                        splashColor: DropdownColors.primary,
-                        onTap: () => setState(() {
-                          // User has started entering text
-                          _textEntered = true;
-                          formControllerWebId.text = suggestionList[index];
-                        }),
-                      );
-                    },
-                  ),
-                  // ),
-                ),
+                boxedSuggestionList(context, suggestionList),
               ] else ...[
-                SizedBox(
-                  width: MediaQuery.of(context).size.width *
-                      0.6, // or double.maxFinite
-                  height: 120,
-                  child: ListView.separated(
-                    padding: const EdgeInsets.all(10),
-                    itemCount: webIdList.length,
-                    separatorBuilder: (context, index) => const Divider(),
-                    itemBuilder: (context, index) {
-                      return ListTile(
-                        title: Text(webIdList[index]),
-                        hoverColor: DropdownColors.accent,
-                        splashColor: DropdownColors.primary,
-                        onTap: () => setState(() {
-                          // User has started entering text
-                          _textEntered = true;
-                          formControllerWebId.text = webIdList[index];
-                        }),
-                      );
-                    },
-                  ),
-                  // ),
-                ),
+                boxedSuggestionList(context, webIdList),
+                // SizedBox(
+                //   width: MediaQuery.of(context).size.width *
+                //       0.6, // or double.maxFinite
+                //   height: 120,
+                //   child: ListView.separated(
+                //     padding: const EdgeInsets.all(10),
+                //     itemCount: webIdList.length,
+                //     separatorBuilder: (context, index) => const Divider(),
+                //     itemBuilder: (context, index) {
+                //       return ListTile(
+                //         title: Text(webIdList[index]),
+                //         hoverColor: DropdownColors.accent,
+                //         splashColor: DropdownColors.primary,
+                //         onTap: () => setState(() {
+                //           // User has started entering text
+                //           _textEntered = true;
+                //           formControllerWebId.text = webIdList[index];
+                //         }),
+                //       );
+                //     },
+                //   ),
+                //   // ),
+                // ),
               ],
             ],
           ],
@@ -278,6 +256,32 @@ class _IndWebIdTextInputState extends State<IndWebIdTextInput> {
           child: const Text('Cancel'),
         ),
       ],
+    );
+  }
+
+  SizedBox boxedSuggestionList(BuildContext context, List<String> idList) {
+    return SizedBox(
+      width: MediaQuery.of(context).size.width * 0.6, // or double.maxFinite
+      height: 120,
+      child: ListView.separated(
+        padding: const EdgeInsets.all(10),
+        itemCount: idList.length,
+        separatorBuilder: (context, index) => const Divider(),
+        itemBuilder: (context, index) {
+          return ListTile(
+            title: Text(idList[index]),
+            focusColor: SecurityColors.primary,
+            hoverColor: DropdownColors.accent,
+            splashColor: DropdownColors.primary,
+            onTap: () => setState(() {
+              // User has started entering text
+              _textEntered = true;
+              formControllerWebId.text = idList[index];
+            }),
+          );
+        },
+      ),
+      // ),
     );
   }
 }

--- a/lib/src/widgets/ind_webid_input_screen.dart
+++ b/lib/src/widgets/ind_webid_input_screen.dart
@@ -1,0 +1,114 @@
+/// A screen to retrieve all the webids of recipients of a user's Pod files before loading the webid input dialog.
+///
+// Time-stamp: <Monday 2025-07-28 12:29:01 +1000 Jess Moore>
+///
+/// Copyright (C) 2025, Software Innovation Institute, ANU.
+///
+/// Licensed under the GNU General Public License, Version 3 (the "License").
+///
+/// License: https://www.gnu.org/licenses/gpl-3.0.en.html.
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later
+// version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
+// details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <https://www.gnu.org/licenses/>.
+///
+///
+/// Authors: Jess Moore
+
+library;
+
+import 'package:flutter/material.dart';
+
+import 'package:solidpod/src/solid/constants/ui.dart';
+import 'package:solidpod/src/solid/get_recipient_list.dart';
+import 'package:solidpod/src/widgets/ind_webid_input_dialog.dart';
+import 'package:solidpod/src/widgets/loading_screen.dart';
+
+/// A screen that runs before opening the WebID input dialog, which
+/// retrieves the list of files in the owner's pod.
+/// Calling this class requires the following inputs:
+/// [onSubmitFunction] is the function to be called on submit
+///
+class IndWebIdInputScreen extends StatefulWidget {
+  /// Initialise widget variables.
+  const IndWebIdInputScreen({required this.onSubmitFunction, super.key});
+
+  /// Function run on Submit button press.
+  final Function onSubmitFunction;
+
+  @override
+  State<IndWebIdInputScreen> createState() => _IndWebIdInputScreenState();
+}
+
+class _IndWebIdInputScreenState extends State<IndWebIdInputScreen> {
+  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
+
+  /// Future comprising the unique recipient list of the user's Pod data
+  static Future<List<String>>? _asyncGetRecipList;
+
+  @override
+  void initState() {
+    _asyncGetRecipList = getRecipientList(
+      context,
+      IndWebIdInputScreen(
+        onSubmitFunction: widget.onSubmitFunction,
+      ),
+    );
+    super.initState();
+  }
+
+  // Load Individual WebId Text Input
+  Widget _loadIndWebIdTextInput(
+    Function onSubmitFunction, [
+    List<String> uniqRecipWebIdList = const [],
+  ]) {
+    return Container(
+      color: Colors.white,
+
+      // Run get access lists fetching screen
+      child: IndWebIdTextInput(
+        onSubmitFunction: onSubmitFunction,
+        uniqRecipWebIdList: uniqRecipWebIdList,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      key: _scaffoldKey,
+      body: SafeArea(
+        child: FutureBuilder(
+          future: _asyncGetRecipList,
+          builder: (context, snapshot) {
+            Widget returnVal;
+            if (snapshot.connectionState == ConnectionState.done) {
+              return snapshot.data == null ||
+                      snapshot.data.toString() == 'null' ||
+                      snapshot.data == []
+                  // Load Individual WebId Input Dialog Screen without recipient list
+                  ? returnVal = _loadIndWebIdTextInput(widget.onSubmitFunction)
+                  // Load Individual WebId Input Dialog Screen with recipient list
+                  : returnVal = _loadIndWebIdTextInput(
+                      widget.onSubmitFunction,
+                      snapshot.data!,
+                    );
+            } else {
+              returnVal = loadingScreen(normalLoadingScreenHeight);
+            }
+            return returnVal;
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/ind_webid_input_screen.dart
+++ b/lib/src/widgets/ind_webid_input_screen.dart
@@ -40,10 +40,20 @@ import 'package:solidpod/src/widgets/loading_screen.dart';
 ///
 class IndWebIdInputScreen extends StatefulWidget {
   /// Initialise widget variables.
-  const IndWebIdInputScreen({required this.onSubmitFunction, super.key});
+  const IndWebIdInputScreen({
+    required this.onSubmitFunction,
+    this.dataFilesMap = const {},
+    super.key,
+  });
 
   /// Function run on Submit button press.
   final Function onSubmitFunction;
+
+  /// Map of data files on a user's POD used to extract the
+  /// user's recipient list by the WebIdTextInputScreen.
+  /// If not provided, the file list must be read to obtain
+  /// the user's recipient list used in the WebIdTextInputScreen.
+  final Map<String, dynamic> dataFilesMap;
 
   @override
   State<IndWebIdInputScreen> createState() => _IndWebIdInputScreenState();
@@ -52,17 +62,26 @@ class IndWebIdInputScreen extends StatefulWidget {
 class _IndWebIdInputScreenState extends State<IndWebIdInputScreen> {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
 
-  /// Future comprising the unique recipient list of the user's Pod data
+  /// Future comprising the unique recipient WebId list of the user's Pod data.
   static Future<List<String>>? _asyncGetRecipList;
+
+  /// List of unique recipient WebId list of the user's Pod data.
+  List<String> uniqRecipWebIdList = [];
 
   @override
   void initState() {
-    _asyncGetRecipList = getRecipientList(
-      context,
-      IndWebIdInputScreen(
-        onSubmitFunction: widget.onSubmitFunction,
-      ),
-    );
+    // Retrieve files and derive unique recipient WebId list.
+    if (widget.dataFilesMap.isEmpty) {
+      _asyncGetRecipList = getRecipientList(
+        context,
+        IndWebIdInputScreen(
+          onSubmitFunction: widget.onSubmitFunction,
+        ),
+      );
+    } else {
+      // Extract unique recipient WebId list if file data provided.
+      uniqRecipWebIdList = extractRecipWebIdList(widget.dataFilesMap);
+    }
     super.initState();
   }
 
@@ -87,27 +106,33 @@ class _IndWebIdInputScreenState extends State<IndWebIdInputScreen> {
     return Scaffold(
       key: _scaffoldKey,
       body: SafeArea(
-        child: FutureBuilder(
-          future: _asyncGetRecipList,
-          builder: (context, snapshot) {
-            Widget returnVal;
-            if (snapshot.connectionState == ConnectionState.done) {
-              return snapshot.data == null ||
-                      snapshot.data.toString() == 'null' ||
-                      snapshot.data == []
-                  // Load Individual WebId Input Dialog Screen without recipient list
-                  ? returnVal = _loadIndWebIdTextInput(widget.onSubmitFunction)
-                  // Load Individual WebId Input Dialog Screen with recipient list
-                  : returnVal = _loadIndWebIdTextInput(
-                      widget.onSubmitFunction,
-                      snapshot.data!,
-                    );
-            } else {
-              returnVal = loadingScreen(normalLoadingScreenHeight);
-            }
-            return returnVal;
-          },
-        ),
+        child: (widget.dataFilesMap.isNotEmpty)
+            ? _loadIndWebIdTextInput(
+                widget.onSubmitFunction,
+                uniqRecipWebIdList,
+              )
+            : FutureBuilder(
+                future: _asyncGetRecipList,
+                builder: (context, snapshot) {
+                  Widget returnVal;
+                  if (snapshot.connectionState == ConnectionState.done) {
+                    return snapshot.data == null ||
+                            snapshot.data.toString() == 'null' ||
+                            snapshot.data == []
+                        // Load Individual WebId Input Dialog Screen without recipient list
+                        ? returnVal =
+                            _loadIndWebIdTextInput(widget.onSubmitFunction)
+                        // Load Individual WebId Input Dialog Screen with recipient list
+                        : returnVal = _loadIndWebIdTextInput(
+                            widget.onSubmitFunction,
+                            snapshot.data!,
+                          );
+                  } else {
+                    returnVal = loadingScreen(normalLoadingScreenHeight);
+                  }
+                  return returnVal;
+                },
+              ),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   pointycastle: ^3.9.1
   rdflib: ^0.2.11
   solid_auth: ^0.1.27
+  universal_io: ^2.2.2
   url_launcher: ^6.3.1
 
 dev_dependencies:


### PR DESCRIPTION
# Pull Request Details

**REVIEW this PR with notepod branch jess/get_resources**

## What issue does this PR address

- Implements a clickable suggestion list in the Individual webid text input

- Link to associated issue: #295 
- See notes in comment https://github.com/anusii/solidpod/issues/295#issuecomment-3138435210 

## Checklist

I believe this is a non-breaking change. It adds an optional parameter comprising map of files and their ACLs to GrantPermissionUI. Apps such as NotePod which already fetch that data for ListNotes(), should pass the data to the sharing button call to GrantPermissionUI(). This avoids running a future to retrieve in when the Individual WebID button is clicked.

Tested on apps:
- [x] NotePod - in PR jess/get_resources - see screenshots in issue.
- [ ] Another app - please test on another app that calls GrantPermissionUI()

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [x] Chrome
  - [x] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
- [x] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev
