### PR TITLE
Fix shared key reading issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Visit the package at [pub.dev](https://pub.dev/packages/solidpod).
 
 ## 0.8 Updated API for readPod/writePod
 
-+ Shared jey reading bug fix [0.7.10 20250916 anushkavidanage]
++ Shared key reading bug fix [0.7.10 20250916 anushkavidanage]
 + Bug fix in key manager [0.7.9 20250815 atangster]
 + Bug fix for default logo/splash images [0.7.8 20250813 anushkavidanage]
 + Improve solid login widget tooltips [0.7.7 20250811 gjw]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Visit the package at [pub.dev](https://pub.dev/packages/solidpod).
 
 ## 0.8 Updated API for readPod/writePod
 
++ Shared jey reading bug fix [0.7.10 20250916 anushkavidanage]
 + Bug fix in key manager [0.7.9 20250815 atangster]
 + Bug fix for default logo/splash images [0.7.8 20250813 anushkavidanage]
 + Improve solid login widget tooltips [0.7.7 20250811 gjw]

--- a/example/lib/home.dart
+++ b/example/lib/home.dart
@@ -536,7 +536,7 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
                             MaterialPageRoute(
                               builder: (context) => const GrantPermissionUi(
                                 backgroundColor: titleBackgroundColor,
-                                fileName: 'key-value.ttl',
+                                fileName: 'keyvalue/key-value.ttl',
                                 // accessModeList: ['read', 'write'],
                                 // recipientTypeList: ['indi', 'group'],
                                 child: Home(),
@@ -550,7 +550,8 @@ class HomeState extends State<Home> with SingleTickerProviderStateMixin {
                           onPressed: () => Navigator.push(
                             context,
                             MaterialPageRoute(
-                              builder: (context) => const PermissionCallbackDemo(
+                              builder: (context) =>
+                                  const PermissionCallbackDemo(
                                 child: Home(),
                               ),
                             ),

--- a/lib/src/solid/read_external_pod.dart
+++ b/lib/src/solid/read_external_pod.dart
@@ -66,10 +66,11 @@ Future<dynamic> readExternalPod(
       try {
         final fileContent = await fetchPrvFile(fileUrl);
 
+        // Get master key from the user if required
+        await getKeyFromUserIfRequired(context, child);
+
         // Decrypt if reading an encrypted file
         if (await KeyManager.hasSharedIndividualKey(fileUrl)) {
-          await getKeyFromUserIfRequired(context, child);
-
           // Get the individual key for the file
           final indKey = await KeyManager.getSharedIndividualKey(fileUrl);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidpod
 description: Support access to private data from PODs on Solid servers.
-version: 0.7.9
+version: 0.7.10
 homepage: https://github.com/anusii/solidpod
 
 environment:


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Fix shared key reading issue. This was due to the master key being not properly setup at the start of the `readExternalPod()` function.

- Link to associated issue: #

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [ ] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [x] Pre-exisiting lint errors noted: [HERE]
- [x] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [ ] iOS
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
- [ ] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev
