### PR TITLE
Jess/notepod list notes

### DIFF
--- a/lib/solidpod.dart
+++ b/lib/solidpod.dart
@@ -78,6 +78,10 @@ export 'src/solid/utils/app_info.dart';
 
 export 'src/solid/utils/key_helper.dart' show KeyManager;
 
+/// Includes common TTL conversion functions such as parseTTLMap.
+
+export 'src/solid/utils/rdf.dart' show parseTTLMap;
+
 /// Includes common functions that could be useful for an app such as
 /// - get web id of the user
 /// - get path of a directory or file

--- a/lib/src/solid/get_access_lists.dart
+++ b/lib/src/solid/get_access_lists.dart
@@ -54,6 +54,14 @@ Future<Map<String, dynamic>> getAccessLists(
   List<String>? fileList,
 }) async {
   fileList = fileList ?? dataMap.keys.toList();
+  final bool isExternalRes;
+
+  // File path
+  if (isFilePath) {
+    isExternalRes = true;
+  } else {
+    isExternalRes = false;
+  }
 
   // Read recipients for each file
   for (final fileName in fileList) {
@@ -65,7 +73,7 @@ Future<Map<String, dynamic>> getAccessLists(
       fileFlag,
       context,
       child,
-      isExternalRes: true,
+      isExternalRes: isExternalRes,
     );
     // Create empty map for each file if dataMap lacks file data
     if (!dataMap.containsKey(fileName)) {


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Allows getAccessLists() to work correctly when called with isFilePath = false, which is now used in notepod

- Link to associated issue: notepod issue https://github.com/anusii/notepod/issues/248
- Test with notepod PR https://github.com/anusii/notepod/pull/259

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

Flutter Style Guide: https://survivor.togaware.com/gnulinux/flutter-style.html

- [x] Screenshots included in linked issue
- [x] Changes adhere to the team style and coding guideline
- [x] No confidential information
- [x] No duplicated content
- [x] No lint check errors related to your changes (`make prep` or `flutter analyze lib`)
- [ ] Pre-exisiting lint errors noted: [HERE]
- [ ] Tested on at least one device
  - [ ] Android Phone
  - [ ] Android Emulator
  - [ ] Chrome on Android
  - [ ] Chrome
  - [x] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
- [ ] Added 2 reviewers (or 1 for private repositories then they add another)

## Finalising

Once PR discussion is complete and 2 reviewers have approved:

- [ ] Merge dev into the branch
- [ ] Resolve any conflicts
- [ ] Add one line summary into CHANGELOG.md
- [ ] Bump appropriate version number in pubspec.yaml
- [ ] Push to git repository and review
- [ ] Merge PR into dev
