### PR TITLE
Add missing 'revoke' record to permission log for already deleted files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Visit the package at [pub.dev](https://pub.dev/packages/solidpod).
 
 ## 0.8 Updated API for readPod/writePod
 
++ Revoke access on already deleted files [0.7.18 20251103 jesscmoore]
 + Remove circular dependency with solidui [0.7.17 20251029 tonypioneer]
 + Read shared resource with inheritance [0.7.16 20251027 anushkavidanage]
 + Migrate SolidLogin to solidui [0.7.15 20251027 tonypioneer]

--- a/lib/solidpod.dart
+++ b/lib/solidpod.dart
@@ -170,9 +170,17 @@ export 'src/solid/write_external_pod.dart';
 export 'src/solid/utils/rdf.dart' show turtleToTripleMap, tripleMapToTurtle;
 
 /// 20250917 gjw Extras that were required for notepod. Not yet documented.
+/// 20251103 jesscmoore In common.dart, only authUserPred is
+/// used by notepod
 
 export 'src/solid/constants/common.dart' show dataDir, profCard, authUserPred;
+
+/// Adds the permission data to a data map for a file in a user's POD
+
 export 'src/solid/get_access_lists.dart';
+
+/// Function to get resources in a user's POD
+
 export 'src/solid/get_resources.dart';
 
 /// 20250917 gjw Extras that were required for the example app! Not yet

--- a/lib/solidpod.dart
+++ b/lib/solidpod.dart
@@ -148,11 +148,14 @@ export 'src/solid/api/rest_api.dart'
     show getResourcesInContainer, initialStructureTest;
 
 /// Function to get the latest log enties
-/// Function to create log entry
-/// Function to update log
 
 export 'src/solid/api/common_permission.dart'
-    show PermissionLogLiteral, getLatestLog, createPermLogEntry, addPermLogLine;
+    show PermissionLogLiteral, getLatestLog;
+
+/// Function to revoke permission to a deleted file
+
+export 'src/solid/revoke_permission_to_deleted_file.dart'
+    show revokePermissionToDelFile;
 
 /// Read encrypted/non-encrypted files stored in an external POD
 

--- a/lib/solidpod.dart
+++ b/lib/solidpod.dart
@@ -148,9 +148,11 @@ export 'src/solid/api/rest_api.dart'
     show getResourcesInContainer, initialStructureTest;
 
 /// Function to get the latest log enties
+/// Function to create log entry
+/// Function to update log
 
 export 'src/solid/api/common_permission.dart'
-    show PermissionLogLiteral, getLatestLog;
+    show PermissionLogLiteral, getLatestLog, createPermLogEntry, addPermLogLine;
 
 /// Read encrypted/non-encrypted files stored in an external POD
 

--- a/lib/src/solid/api/common_permission.dart
+++ b/lib/src/solid/api/common_permission.dart
@@ -30,11 +30,13 @@
 
 library;
 
+import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 import 'package:solidpod/src/solid/api/rest_api.dart';
 import 'package:solidpod/src/solid/constants/common.dart';
 import 'package:solidpod/src/solid/constants/schema.dart';
+import 'package:solidpod/src/solid/models/log_entry.dart';
 
 /// A class to represent permission log literals
 enum PermissionLogLiteral {
@@ -80,7 +82,8 @@ enum PermissionLogLiteral {
 ///   - permissionList: List of access types (Read, Write, Control, Append)
 ///
 /// Returns the log entry ID and the log entry string
-List<dynamic> createPermLogEntry(
+// List<dynamic> createPermLogEntry(
+LogEntry createPermLogEntry(
   List<dynamic> permissionList,
   String resourceUrl,
   String ownerWebId,
@@ -88,13 +91,18 @@ List<dynamic> createPermLogEntry(
   String granterWebId,
   String recepientWebId,
 ) {
+  // Create log entry object
+  final LogEntry logEntry;
   final permissionListStr = permissionList.join(',');
   final dateTimeStr = DateFormat('yyyyMMddTHHmmss').format(DateTime.now());
   final logEntryId = DateFormat('yyyyMMddTHHmmssSSS').format(DateTime.now());
   final logEntryStr =
       '$dateTimeStr;$resourceUrl;$ownerWebId;$permissionType;$granterWebId;$recepientWebId;${permissionListStr.toLowerCase()}';
 
-  return [logEntryId, logEntryStr];
+  logEntry = LogEntry(id: logEntryId, record: logEntryStr);
+
+  // return [logEntryId, logEntryStr];
+  return logEntry;
 }
 
 /// Add permission log line to the log file
@@ -108,6 +116,8 @@ Future<void> addPermLogLine(
   const prefix2 = '$dataPrefix <$appsData>';
   final insertQuery =
       'PREFIX $prefix1 PREFIX $prefix2 INSERT DATA {$logIdPrefix$logEntryId ${dataPrefix}log "<$logEntryStr>"};';
+
+  debugPrint('[addPermLogLine] $insertQuery');
 
   // Update the file using the insert query
   await updateFileByQuery(logFileUrl, insertQuery);

--- a/lib/src/solid/api/common_permission.dart
+++ b/lib/src/solid/api/common_permission.dart
@@ -82,15 +82,14 @@ enum PermissionLogLiteral {
 ///   - permissionList: List of access types (Read, Write, Control, Append)
 ///
 /// Returns the log entry ID and the log entry string
-// List<dynamic> createPermLogEntry(
-LogEntry createPermLogEntry(
-  List<dynamic> permissionList,
-  String resourceUrl,
-  String ownerWebId,
-  String permissionType,
-  String granterWebId,
-  String recepientWebId,
-) {
+LogEntry createPermLogEntry({
+  required List<dynamic> permissionList,
+  required String resourceUrl,
+  required String ownerWebId,
+  required String permissionType,
+  required String granterWebId,
+  required String recepientWebId,
+}) {
   // Create log entry object
   final LogEntry logEntry;
   final permissionListStr = permissionList.join(',');
@@ -101,21 +100,20 @@ LogEntry createPermLogEntry(
 
   logEntry = LogEntry(id: logEntryId, record: logEntryStr);
 
-  // return [logEntryId, logEntryStr];
   return logEntry;
 }
 
 /// Add permission log line to the log file
-Future<void> addPermLogLine(
-  String logFileUrl,
-  String logEntryId,
-  String logEntryStr,
-) async {
+/// TODO: add doc string
+Future<void> addPermLogLine({
+  required String logFileUrl,
+  required LogEntry logEntry,
+}) async {
   // Generate insert sparql query for log entry
   const prefix1 = '$logIdPrefix <$appsLogId>';
   const prefix2 = '$dataPrefix <$appsData>';
   final insertQuery =
-      'PREFIX $prefix1 PREFIX $prefix2 INSERT DATA {$logIdPrefix$logEntryId ${dataPrefix}log "<$logEntryStr>"};';
+      'PREFIX $prefix1 PREFIX $prefix2 INSERT DATA {$logIdPrefix${logEntry.id} ${dataPrefix}log "<${logEntry.record}>"};';
 
   debugPrint('[addPermLogLine] $insertQuery');
 

--- a/lib/src/solid/api/common_permission.dart
+++ b/lib/src/solid/api/common_permission.dart
@@ -30,7 +30,6 @@
 
 library;
 
-import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 import 'package:solidpod/src/solid/api/rest_api.dart';
@@ -71,17 +70,22 @@ enum PermissionLogLiteral {
   String get label => _value;
 }
 
-/// Create a log entry for permission
-/// A log entry consists of 7 values
-///   - dateTimeStr: Permission granted/revoked date and time
-///   - resourceUrl: URL of the resource that is being shared/un-shared
-///   - ownerWebId: WebID of the resource owner
-///   - permissionType: Type of permission (grant/revoke)
-///   - granterWebId: WebID of the person who is giving/revoking permission
-///   - recepientWebId: WebID of the person who is reveiving permission
-///   - permissionList: List of access types (Read, Write, Control, Append)
+/// Create a log entry for adding to someone's permission log
+/// to change the level of access of a user to a file in a Pod.
+/// A log entry consists of 7 values, each of which are required
+/// parameters.
 ///
-/// Returns the log entry ID and the log entry string
+/// Parameters:
+///  - [resourceUrl]: URL of the resource that is being shared/un-shared
+///  - [ownerWebId]: WebID of the resource owner
+///  - [permissionType]: Type of permission (grant/revoke)
+///  - [granterWebId]: WebID of the person who is giving/revoking permission
+///   - [recepientWebId]: WebID of the person who is reveiving permission
+///   - [permissionList]: List of access types that is being granted
+/// or revoked (Read, Write, Control, Append).
+///
+/// Returns the log entry object ([LogEntry]) comprising ID and
+/// the log record string.
 LogEntry createPermLogEntry({
   required List<dynamic> permissionList,
   required String resourceUrl,
@@ -103,8 +107,15 @@ LogEntry createPermLogEntry({
   return logEntry;
 }
 
-/// Add permission log line to the log file
-/// TODO: add doc string
+/// Add permission log record to a permission log file
+/// [logFileUrl].
+///
+/// Arguments:
+/// - [logFileUrl] - url of the permission log file that
+/// the record is being appended to.
+/// - [logEntry] - log entry record to append to permission
+/// log.
+
 Future<void> addPermLogLine({
   required String logFileUrl,
   required LogEntry logEntry,
@@ -114,8 +125,6 @@ Future<void> addPermLogLine({
   const prefix2 = '$dataPrefix <$appsData>';
   final insertQuery =
       'PREFIX $prefix1 PREFIX $prefix2 INSERT DATA {$logIdPrefix${logEntry.id} ${dataPrefix}log "<${logEntry.record}>"};';
-
-  debugPrint('[addPermLogLine] $insertQuery');
 
   // Update the file using the insert query
   await updateFileByQuery(logFileUrl, insertQuery);

--- a/lib/src/solid/grant_permission.dart
+++ b/lib/src/solid/grant_permission.dart
@@ -38,6 +38,7 @@ import 'package:solidpod/src/solid/api/rest_api.dart';
 import 'package:solidpod/src/solid/common_func.dart';
 import 'package:solidpod/src/solid/constants/common.dart';
 import 'package:solidpod/src/solid/constants/web_acl.dart';
+import 'package:solidpod/src/solid/models/log_entry.dart';
 import 'package:solidpod/src/solid/solid_func_call_status.dart';
 import 'package:solidpod/src/solid/utils/authdata_manager.dart';
 import 'package:solidpod/src/solid/utils/exceptions.dart';
@@ -191,7 +192,8 @@ Future<SolidFunctionCallStatus> grantPermission({
           final userWebId = await AuthDataManager.getWebId() as String;
 
           for (final recipientWebId in recipientWebIdList) {
-            final logEntryRes = createPermLogEntry(
+            // final logEntryRes = createPermLogEntry(
+            final LogEntry logEntryRes = createPermLogEntry(
               permissionList,
               resourceUrl,
               ownerWebId,
@@ -212,8 +214,10 @@ Future<SolidFunctionCallStatus> grantPermission({
             // Run log entry insert query for the granter
             await addPermLogLine(
               granterLogFileUrl,
-              logEntryRes[0] as String,
-              logEntryRes[1] as String,
+              // logEntryRes[0] as String,
+              // logEntryRes[1] as String,
+              logEntryRes.id,
+              logEntryRes.record,
             );
 
             // If owner and the granter is not the same add another log file entry
@@ -221,8 +225,10 @@ Future<SolidFunctionCallStatus> grantPermission({
             if (ownerLogFileUrl != granterLogFileUrl) {
               await addPermLogLine(
                 ownerLogFileUrl,
-                logEntryRes[0] as String,
-                logEntryRes[1] as String,
+                // logEntryRes[0] as String,
+                // logEntryRes[1] as String,
+                logEntryRes.id,
+                logEntryRes.record,
               );
             }
 
@@ -234,8 +240,10 @@ Future<SolidFunctionCallStatus> grantPermission({
 
               await addPermLogLine(
                 receiverLogFileUrl,
-                logEntryRes[0] as String,
-                logEntryRes[1] as String,
+                // logEntryRes[0] as String,
+                // logEntryRes[1] as String,
+                logEntryRes.id,
+                logEntryRes.record,
               );
             }
           }

--- a/lib/src/solid/grant_permission.dart
+++ b/lib/src/solid/grant_permission.dart
@@ -192,14 +192,13 @@ Future<SolidFunctionCallStatus> grantPermission({
           final userWebId = await AuthDataManager.getWebId() as String;
 
           for (final recipientWebId in recipientWebIdList) {
-            // final logEntryRes = createPermLogEntry(
             final LogEntry logEntryRes = createPermLogEntry(
-              permissionList,
-              resourceUrl,
-              ownerWebId,
-              'grant',
-              userWebId,
-              recipientWebId as String,
+              permissionList: permissionList,
+              resourceUrl: resourceUrl,
+              ownerWebId: ownerWebId,
+              permissionType: 'grant',
+              granterWebId: userWebId,
+              recepientWebId: recipientWebId as String,
             );
 
             // Log file urls of the owner, granter, and receiver
@@ -213,22 +212,16 @@ Future<SolidFunctionCallStatus> grantPermission({
 
             // Run log entry insert query for the granter
             await addPermLogLine(
-              granterLogFileUrl,
-              // logEntryRes[0] as String,
-              // logEntryRes[1] as String,
-              logEntryRes.id,
-              logEntryRes.record,
+              logFileUrl: granterLogFileUrl,
+              logEntry: logEntryRes,
             );
 
             // If owner and the granter is not the same add another log file entry
             // for the owner
             if (ownerLogFileUrl != granterLogFileUrl) {
               await addPermLogLine(
-                ownerLogFileUrl,
-                // logEntryRes[0] as String,
-                // logEntryRes[1] as String,
-                logEntryRes.id,
-                logEntryRes.record,
+                logFileUrl: ownerLogFileUrl,
+                logEntry: logEntryRes,
               );
             }
 
@@ -239,11 +232,8 @@ Future<SolidFunctionCallStatus> grantPermission({
                   await getFileUrl(logFilePath, recipientWebId);
 
               await addPermLogLine(
-                receiverLogFileUrl,
-                // logEntryRes[0] as String,
-                // logEntryRes[1] as String,
-                logEntryRes.id,
-                logEntryRes.record,
+                logFileUrl: receiverLogFileUrl,
+                logEntry: logEntryRes,
               );
             }
           }

--- a/lib/src/solid/models/log_entry.dart
+++ b/lib/src/solid/models/log_entry.dart
@@ -1,0 +1,41 @@
+/// Data model for permission log in a POD.
+///
+/// Copyright (C) 2024, Software Innovation Institute, ANU.
+///
+/// Licensed under the MIT License (the "License").
+///
+/// License: https://choosealicense.com/licenses/mit/.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+///
+/// Authors: Jess Moore
+
+library;
+
+/// Data model for entries in the permission log record in a Pod
+
+class LogEntry {
+  final String id;
+  final String record;
+
+  const LogEntry({
+    required this.id,
+    required this.record,
+  });
+}

--- a/lib/src/solid/read_external_pod.dart
+++ b/lib/src/solid/read_external_pod.dart
@@ -37,6 +37,7 @@ import 'package:encrypter_plus/encrypter_plus.dart';
 import 'package:solidpod/src/solid/api/rest_api.dart';
 import 'package:solidpod/src/solid/common_func.dart';
 import 'package:solidpod/src/solid/constants/common.dart';
+import 'package:solidpod/src/solid/solid_func_call_status.dart';
 import 'package:solidpod/src/solid/utils/exceptions.dart';
 import 'package:solidpod/src/solid/utils/key_helper.dart';
 import 'package:solidpod/src/solid/utils/misc.dart';
@@ -114,5 +115,6 @@ Future<dynamic> readExternalPod(
   }
 
   debugPrint('Resource "$fileUrl" does not exist.');
-  return null;
+  // return null;
+  return SolidFunctionCallStatus.fileNotExists;
 }

--- a/lib/src/solid/revoke_permission.dart
+++ b/lib/src/solid/revoke_permission.dart
@@ -146,14 +146,13 @@ Future<SolidFunctionCallStatus> revokePermission({
     final userWebId = await AuthDataManager.getWebId() as String;
 
     for (final removerWebId in removerWebIdList) {
-      // final logEntryRes = createPermLogEntry(
       final LogEntry logEntryRes = createPermLogEntry(
-        permissionList,
-        resourceUrl,
-        ownerWebId,
-        'revoke',
-        userWebId,
-        removerWebId as String,
+        permissionList: permissionList,
+        resourceUrl: resourceUrl,
+        ownerWebId: ownerWebId,
+        permissionType: 'revoke',
+        granterWebId: userWebId,
+        recepientWebId: removerWebId as String,
       );
 
       // Log file urls of the owner, granter, and receiver
@@ -171,22 +170,16 @@ Future<SolidFunctionCallStatus> revokePermission({
 
       // Run log entry insert query for the granter
       await addPermLogLine(
-        granterLogFileUrl,
-        // logEntryRes[0] as String,
-        // logEntryRes[1] as String,
-        logEntryRes.id,
-        logEntryRes.record,
+        logFileUrl: granterLogFileUrl,
+        logEntry: logEntryRes,
       );
 
       // If owner and the granter is not the same add another log file entry
       // for the owner
       if (ownerLogFileUrl != granterLogFileUrl) {
         await addPermLogLine(
-          ownerLogFileUrl,
-          // logEntryRes[0] as String,
-          // logEntryRes[1] as String,
-          logEntryRes.id,
-          logEntryRes.record,
+          logFileUrl: ownerLogFileUrl,
+          logEntry: logEntryRes,
         );
       }
 
@@ -197,11 +190,8 @@ Future<SolidFunctionCallStatus> revokePermission({
           final receiverLogFileUrl =
               await getFileUrl(logFilePath, removerWebId);
           await addPermLogLine(
-            receiverLogFileUrl,
-            // logEntryRes[0] as String,
-            // logEntryRes[1] as String,
-            logEntryRes.id,
-            logEntryRes.record,
+            logFileUrl: receiverLogFileUrl,
+            logEntry: logEntryRes,
           );
         }
       }

--- a/lib/src/solid/revoke_permission.dart
+++ b/lib/src/solid/revoke_permission.dart
@@ -35,6 +35,7 @@ import 'package:solidpod/src/solid/api/rest_api.dart';
 import 'package:solidpod/src/solid/api/revoke_permission_api.dart';
 import 'package:solidpod/src/solid/constants/common.dart';
 import 'package:solidpod/src/solid/constants/web_acl.dart';
+import 'package:solidpod/src/solid/models/log_entry.dart';
 import 'package:solidpod/src/solid/solid_func_call_status.dart';
 import 'package:solidpod/src/solid/utils/authdata_manager.dart';
 import 'package:solidpod/src/solid/utils/misc.dart';
@@ -145,7 +146,8 @@ Future<SolidFunctionCallStatus> revokePermission({
     final userWebId = await AuthDataManager.getWebId() as String;
 
     for (final removerWebId in removerWebIdList) {
-      final logEntryRes = createPermLogEntry(
+      // final logEntryRes = createPermLogEntry(
+      final LogEntry logEntryRes = createPermLogEntry(
         permissionList,
         resourceUrl,
         ownerWebId,
@@ -170,8 +172,10 @@ Future<SolidFunctionCallStatus> revokePermission({
       // Run log entry insert query for the granter
       await addPermLogLine(
         granterLogFileUrl,
-        logEntryRes[0] as String,
-        logEntryRes[1] as String,
+        // logEntryRes[0] as String,
+        // logEntryRes[1] as String,
+        logEntryRes.id,
+        logEntryRes.record,
       );
 
       // If owner and the granter is not the same add another log file entry
@@ -179,8 +183,10 @@ Future<SolidFunctionCallStatus> revokePermission({
       if (ownerLogFileUrl != granterLogFileUrl) {
         await addPermLogLine(
           ownerLogFileUrl,
-          logEntryRes[0] as String,
-          logEntryRes[1] as String,
+          // logEntryRes[0] as String,
+          // logEntryRes[1] as String,
+          logEntryRes.id,
+          logEntryRes.record,
         );
       }
 
@@ -192,8 +198,10 @@ Future<SolidFunctionCallStatus> revokePermission({
               await getFileUrl(logFilePath, removerWebId);
           await addPermLogLine(
             receiverLogFileUrl,
-            logEntryRes[0] as String,
-            logEntryRes[1] as String,
+            // logEntryRes[0] as String,
+            // logEntryRes[1] as String,
+            logEntryRes.id,
+            logEntryRes.record,
           );
         }
       }

--- a/lib/src/solid/revoke_permission_to_deleted_file.dart
+++ b/lib/src/solid/revoke_permission_to_deleted_file.dart
@@ -36,15 +36,15 @@ import 'package:solidpod/src/solid/api/rest_api.dart';
 import 'package:solidpod/src/solid/models/log_entry.dart';
 import 'package:solidpod/src/solid/api/revoke_permission_api.dart';
 import 'package:solidpod/src/solid/solid_func_call_status.dart';
-import 'package:solidpod/src/solid/utils/authdata_manager.dart';
 import 'package:solidpod/src/solid/utils/misc.dart';
 
 /// Revoke permissions to non-existent [fileName] (ie already deleted)
 /// for a given individual Web ID [removerWebId].
 /// Note: assumed for use case of user updating their own logs to
 /// revoke their access to an external file that has already been
-/// deleted without prior revoking of access to recipients. I.e. the
-/// user and the remover are the same.
+/// deleted without prior revoking of access to recipients. This is
+/// the case for files deleted before revoking was included in the
+/// delete process, or files deleted on the server.
 ///
 /// Parameters:
 /// - [fileName] - is the name of the file revoking permission from.
@@ -53,6 +53,8 @@ import 'package:solidpod/src/solid/utils/misc.dart';
 /// - [removerWebId] - is the Web ID of the individual for whom access is
 /// being removed.
 /// - [ownerWebId] - is the Web ID of file owner.
+/// - [granterWebId] - is the Web ID of the granter of this access
+/// to the file.
 /// - [isFileUrl] - flag describing whether the [fileName] is the url
 /// of the resource. (Default: false).
 
@@ -62,71 +64,69 @@ Future<SolidFunctionCallStatus> revokePermissionToDelFile({
   required List<dynamic> permissionList,
   required String removerWebId,
   required String ownerWebId,
+  required String granterWebId,
   bool isFileUrl = false,
 }) async {
-  debugPrint(
-    '[revokePermissionsToDelFile] revoking permissions for: $removerWebId to $fileName',
-  );
-  // Applies to external files only
-  final isExternalRes = true;
-  final isFile = true;
-
-  // Get Url of file
-  final resourceUrl = await filenameToResourceUrl(
-    fileName: fileName,
-    isFile: isFile,
-    isFileUrl: isFileUrl,
-    isExternalRes: isExternalRes,
-  );
-
-  // If the file is encrypted then remove the individual key from relavant
-  // users/ user classes
-  if (isFileEncrypted) {
-    // Check if POD file structure is still there
-    if (await checkPodInitialised(removerWebId)) {
-      // Generate unique ID for the resource being shared
-      final resUniqueId = getUniqueIdResUrl(resourceUrl, removerWebId);
-
-      // Delete shared key content from recipient's POD
-      await removeSharedKey(removerWebId, resUniqueId);
-    }
-  }
-
-  // Add log entry to receiver permission log files
-
-  // Get user webID
-  final userWebId = await AuthDataManager.getWebId() as String;
-
-  // Create log entry
-  // final logEntryRes = createPermLogEntry(
-  final LogEntry logEntryRes = createPermLogEntry(
-    permissionList,
-    resourceUrl,
-    ownerWebId,
-    'revoke',
-    userWebId,
-    removerWebId,
-  );
-
-  debugPrint('Log entry: ${logEntryRes.id}');
-  debugPrint(logEntryRes.record);
-
-  // Log file urls of the owner, granter, and receiver
-  final logFilePath = await getPermLogFilePath();
-
-  debugPrint('logFilePath: $logFilePath');
-
-  // Add log entry to recipient's log
-  if (await checkPodInitialised(removerWebId)) {
-    final receiverLogFileUrl = await getFileUrl(logFilePath, removerWebId);
-    await addPermLogLine(
-      receiverLogFileUrl,
-      // logEntryRes[0] as String,
-      // logEntryRes[1] as String,
-      logEntryRes.id,
-      logEntryRes.record,
+  try {
+    debugPrint(
+      '[revokePermissionsToDelFile] revoking access to file: $fileName',
     );
-  }
+    debugPrint('for user: $removerWebId');
 
-  return SolidFunctionCallStatus.success;
+    // Applies to external files only
+    final isExternalRes = true;
+    final isFile = true;
+
+    // Get Url of file
+    final resourceUrl = await filenameToResourceUrl(
+      fileName: fileName,
+      isFile: isFile,
+      isFileUrl: isFileUrl,
+      isExternalRes: isExternalRes,
+    );
+
+    // If the file is encrypted then remove the individual key from relavant
+    // users/ user classes
+    if (isFileEncrypted) {
+      // Check if POD file structure is still there
+      if (await checkPodInitialised(removerWebId)) {
+        // Generate unique ID for the resource being shared
+        final resUniqueId = getUniqueIdResUrl(resourceUrl, removerWebId);
+
+        // Delete shared key content from recipient's POD
+        await removeSharedKey(removerWebId, resUniqueId);
+      }
+    }
+
+    // Add revoke log entry to receiver permission log files
+
+    // Create log entry
+    final LogEntry logEntryRes = createPermLogEntry(
+      permissionList: permissionList,
+      resourceUrl: resourceUrl,
+      ownerWebId: ownerWebId,
+      permissionType: 'revoke',
+      granterWebId: granterWebId,
+      recepientWebId: removerWebId,
+    );
+
+    // Log file urls of the owner, granter, and receiver
+    final logFilePath = await getPermLogFilePath();
+
+    // Add log entry to recipient's log
+    if (await checkPodInitialised(removerWebId)) {
+      final receiverLogFileUrl = await getFileUrl(logFilePath, removerWebId);
+      await addPermLogLine(
+        logFileUrl: receiverLogFileUrl,
+        logEntry: logEntryRes,
+      );
+      debugPrint('Revoked access to $fileName in $receiverLogFileUrl');
+    }
+
+    return SolidFunctionCallStatus.success;
+  } on Object catch (e, stackTrace) {
+    debugPrint('💥 [revokePermissionToDelFile] Exception occurred: $e');
+    debugPrint('📚 [revokePermissionToDelFile] Stack trace: $stackTrace');
+    return SolidFunctionCallStatus.fail;
+  }
 }

--- a/lib/src/solid/revoke_permission_to_deleted_file.dart
+++ b/lib/src/solid/revoke_permission_to_deleted_file.dart
@@ -1,0 +1,132 @@
+/// Function to revoke permission to a non existent file in a private file in a POD.
+///
+/// Copyright (C) 2024, Software Innovation Institute, ANU.
+///
+/// Licensed under the MIT License (the "License").
+///
+/// License: https://choosealicense.com/licenses/mit/.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+///
+/// Authors: Jess Moore
+
+library;
+
+import 'dart:core';
+import 'package:flutter/material.dart';
+
+import 'package:solidpod/src/solid/api/common_permission.dart';
+import 'package:solidpod/src/solid/api/rest_api.dart';
+import 'package:solidpod/src/solid/models/log_entry.dart';
+import 'package:solidpod/src/solid/api/revoke_permission_api.dart';
+import 'package:solidpod/src/solid/solid_func_call_status.dart';
+import 'package:solidpod/src/solid/utils/authdata_manager.dart';
+import 'package:solidpod/src/solid/utils/misc.dart';
+
+/// Revoke permissions to non-existent [fileName] (ie already deleted)
+/// for a given individual Web ID [removerWebId].
+/// Note: assumed for use case of user updating their own logs to
+/// revoke their access to an external file that has already been
+/// deleted without prior revoking of access to recipients. I.e. the
+/// user and the remover are the same.
+///
+/// Parameters:
+/// - [fileName] - is the name of the file revoking permission from.
+/// - [isFileEncrypted] - flag denoting whether the file is encrypted.
+/// - [permissionList] - is the list of permissions being revoked.
+/// - [removerWebId] - is the Web ID of the individual for whom access is
+/// being removed.
+/// - [ownerWebId] - is the Web ID of file owner.
+/// - [isFileUrl] - flag describing whether the [fileName] is the url
+/// of the resource. (Default: false).
+
+Future<SolidFunctionCallStatus> revokePermissionToDelFile({
+  required String fileName,
+  required bool isFileEncrypted,
+  required List<dynamic> permissionList,
+  required String removerWebId,
+  required String ownerWebId,
+  bool isFileUrl = false,
+}) async {
+  debugPrint(
+    '[revokePermissionsToDelFile] revoking permissions for: $removerWebId to $fileName',
+  );
+  // Applies to external files only
+  final isExternalRes = true;
+  final isFile = true;
+
+  // Get Url of file
+  final resourceUrl = await filenameToResourceUrl(
+    fileName: fileName,
+    isFile: isFile,
+    isFileUrl: isFileUrl,
+    isExternalRes: isExternalRes,
+  );
+
+  // If the file is encrypted then remove the individual key from relavant
+  // users/ user classes
+  if (isFileEncrypted) {
+    // Check if POD file structure is still there
+    if (await checkPodInitialised(removerWebId)) {
+      // Generate unique ID for the resource being shared
+      final resUniqueId = getUniqueIdResUrl(resourceUrl, removerWebId);
+
+      // Delete shared key content from recipient's POD
+      await removeSharedKey(removerWebId, resUniqueId);
+    }
+  }
+
+  // Add log entry to receiver permission log files
+
+  // Get user webID
+  final userWebId = await AuthDataManager.getWebId() as String;
+
+  // Create log entry
+  // final logEntryRes = createPermLogEntry(
+  final LogEntry logEntryRes = createPermLogEntry(
+    permissionList,
+    resourceUrl,
+    ownerWebId,
+    'revoke',
+    userWebId,
+    removerWebId,
+  );
+
+  debugPrint('Log entry: ${logEntryRes.id}');
+  debugPrint(logEntryRes.record);
+
+  // Log file urls of the owner, granter, and receiver
+  final logFilePath = await getPermLogFilePath();
+
+  debugPrint('logFilePath: $logFilePath');
+
+  // Add log entry to recipient's log
+  if (await checkPodInitialised(removerWebId)) {
+    final receiverLogFileUrl = await getFileUrl(logFilePath, removerWebId);
+    await addPermLogLine(
+      receiverLogFileUrl,
+      // logEntryRes[0] as String,
+      // logEntryRes[1] as String,
+      logEntryRes.id,
+      logEntryRes.record,
+    );
+  }
+
+  return SolidFunctionCallStatus.success;
+}

--- a/lib/src/solid/revoke_permission_to_deleted_file.dart
+++ b/lib/src/solid/revoke_permission_to_deleted_file.dart
@@ -29,12 +29,13 @@
 library;
 
 import 'dart:core';
+
 import 'package:flutter/material.dart';
 
 import 'package:solidpod/src/solid/api/common_permission.dart';
 import 'package:solidpod/src/solid/api/rest_api.dart';
-import 'package:solidpod/src/solid/models/log_entry.dart';
 import 'package:solidpod/src/solid/api/revoke_permission_api.dart';
+import 'package:solidpod/src/solid/models/log_entry.dart';
 import 'package:solidpod/src/solid/solid_func_call_status.dart';
 import 'package:solidpod/src/solid/utils/misc.dart';
 


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Files that were deleted by the user, before revoking access to recipients was added to the deleteFile(), were showing up in the permission logs of recipients, but unable to be loaded as the files were non-existent.
- This PR adds the function revokePermissionToDelFiles() to solidpod and exports is for use by apps that need it, such as notepod, which has users in this situation.
- Client apps should detect non-existent files in their permission log, collate a list, and then call this function on each one.
- After a user confirms they want to revoke access to these files (as is offered in the notepod PR), the revokePermissionToDelFile() will check for any associated residual key and then add a revoke record to the recipient's permission log. 
- No update to the owner's permission log is done, as they have already deleted the file. Likewise, no update to the granter's permission log.
- See the screenshots in the issue.
- For testing with notepod PR.
- Additionally, named parameters was implemented in createPermLogEntry() (as providing 7 parameters of the same type was easy to get wrong), and addPermLogLine(), and a LogEntry data model created.

## Associated Issue

- This PR relates to issue #476 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update -> change log updated

## How Has This Been Tested?

- Use notepod branch https://github.com/anusii/notepod/pull/299 which implements the function in this PR.
- I already had pre-existing records in my permission log of files shared to me that were deleted by the owner. Other reviewers may have to create these. You could create such notes by: 1) As user A, create a note and share it to user B. Temporarily comment out the revoke step in deleteFile() in solidpod. Reload app, login as user A and delete the file. Now if you log in as user B, their permission log will think the file exists.
- In notepod (using associated PR), login as user B and open Shared Notes
- In the dialog of non existent notes, click revoke, and confirm.

REMEMBER: to uncomment the revoke step in deleteFile()
If we fix up the revokePermission functions to support situations where the granter != owner, then we can add support for revoking in deleting of external files.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [x] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [ ] I tested the PR on these devices:
  - [ ] Android
  - [x] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
  - [ ] Web
- [ ] I have identified reviewers
- [ ] The PR has been approved by reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [x] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
