### PR TITLE
Av/force reload shared key files once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Visit the package at [pub.dev](https://pub.dev/packages/solidpod).
 
 ## 0.9 Stabilise
 
++ Enable in-app shared file reload [0.8.6 20251204 anushkavid]
 + Function to read large file as bytes [0.8.5 20251201 anushkavid]
 + Add PathType to readPod/WritePod [0.8.4 20251123 cdawei]
 + Cleanup and update [0.8.3 20251121 gjw]

--- a/lib/src/solid/utils/key_manager.dart
+++ b/lib/src/solid/utils/key_manager.dart
@@ -346,6 +346,9 @@ class KeyManager {
       await _loadIndKey();
     }
     assert(_indKeyMap != null);
+    if (!_indKeyMap!.containsKey(resourceUrl)) {
+      await _loadIndKey(forceReload: true);
+    }
     return _indKeyMap!.containsKey(resourceUrl);
   }
 
@@ -357,9 +360,13 @@ class KeyManager {
 
     assert(_indKeyMap != null);
     if (!_indKeyMap!.containsKey(resourceUrl)) {
-      throw Exception(
-        'Unable to locate the individual key for resource:\n$resourceUrl',
-      );
+      await _loadIndKey(forceReload: true);
+
+      if (!_indKeyMap!.containsKey(resourceUrl)) {
+        throw Exception(
+          'Unable to locate the individual key for resource:\n$resourceUrl',
+        );
+      }
     }
 
     final record = _indKeyMap![resourceUrl];
@@ -452,6 +459,9 @@ class KeyManager {
       await _loadSharedIndKey();
     }
     assert(_sharedIndKeyMap != null);
+    if (!_sharedIndKeyMap!.containsKey(resourceUrl)) {
+      await _loadSharedIndKey(forceReload: true);
+    }
     return _sharedIndKeyMap!.containsKey(resourceUrl);
   }
 
@@ -467,9 +477,13 @@ class KeyManager {
 
     assert(_sharedIndKeyMap != null);
     if (!_sharedIndKeyMap!.containsKey(resourceUrl)) {
-      throw Exception(
-        'Unable to locate the individual key for resource:\n$resourceUrl',
-      );
+      await _loadSharedIndKey(forceReload: true);
+
+      if (!_sharedIndKeyMap!.containsKey(resourceUrl)) {
+        throw Exception(
+          'Unable to locate the shared individual key for resource:\n$resourceUrl',
+        );
+      }
     }
 
     final record = _sharedIndKeyMap![resourceUrl];

--- a/lib/src/solid/utils/key_manager.dart
+++ b/lib/src/solid/utils/key_manager.dart
@@ -346,9 +346,6 @@ class KeyManager {
       await _loadIndKey();
     }
     assert(_indKeyMap != null);
-    if (!_indKeyMap!.containsKey(resourceUrl)) {
-      await _loadIndKey(forceReload: true);
-    }
     return _indKeyMap!.containsKey(resourceUrl);
   }
 
@@ -360,13 +357,9 @@ class KeyManager {
 
     assert(_indKeyMap != null);
     if (!_indKeyMap!.containsKey(resourceUrl)) {
-      await _loadIndKey(forceReload: true);
-
-      if (!_indKeyMap!.containsKey(resourceUrl)) {
-        throw Exception(
-          'Unable to locate the individual key for resource:\n$resourceUrl',
-        );
-      }
+      throw Exception(
+        'Unable to locate the individual key for resource:\n$resourceUrl',
+      );
     }
 
     final record = _indKeyMap![resourceUrl];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidpod
 description: Support access to private data from PODs on Solid servers.
-version: 0.8.5
+version: 0.8.6
 homepage: https://github.com/anusii/solidpod
 
 environment:


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Force reload key maps once when necessary to enable in-app shared file reload. 

## Associated Issue

- This PR relates to issue #

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [ ] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
  - [ ] Web
- [ ] I have identified reviewers
- [ ] The PR has been approved by reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
