### PR TITLE
fix background on grant permission individual recipient dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Visit the package at [pub.dev](https://pub.dev/packages/solidpod).
 
 ## 0.10 Further UI migrations
 
++ Fixes individual recipient dialog background [0.9.2 20260113 jesscmoore]
 + Fixes key creation for encrypting files [0.9.2 20260112 dc]
 + Code cleanup: typos, context checks, remove context/child [0.9.1 20260112 jesscmoore]
 + Updated read/write to remove context and widget [0.9.0 20260108 dc]

--- a/lib/src/widgets/ind_webid_input_screen.dart
+++ b/lib/src/widgets/ind_webid_input_screen.dart
@@ -65,8 +65,6 @@ class IndWebIdInputScreen extends StatefulWidget {
 }
 
 class _IndWebIdInputScreenState extends State<IndWebIdInputScreen> {
-  final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
-
   /// Future comprising the unique recipient WebId list of the user's Pod data.
   static Future<List<String>>? _asyncGetRecipList;
 
@@ -90,50 +88,40 @@ class _IndWebIdInputScreenState extends State<IndWebIdInputScreen> {
     Function onSubmitFunction, [
     List<String> uniqRecipWebIdList = const [],
   ]) {
-    return Container(
-      color: Colors.white,
-
-      // Run get access lists fetching screen
-      child: IndWebIdTextInput(
-        onSubmitFunction: onSubmitFunction,
-        uniqRecipWebIdList: uniqRecipWebIdList,
-      ),
+    return IndWebIdTextInput(
+      onSubmitFunction: onSubmitFunction,
+      uniqRecipWebIdList: uniqRecipWebIdList,
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      key: _scaffoldKey,
-      body: SafeArea(
-        child: (widget.dataFilesMap.isNotEmpty)
-            ? _loadIndWebIdTextInput(
-                widget.onSubmitFunction,
-                uniqRecipWebIdList,
-              )
-            : FutureBuilder(
-                future: _asyncGetRecipList,
-                builder: (context, snapshot) {
-                  Widget returnVal;
-                  if (snapshot.connectionState == ConnectionState.done) {
-                    return snapshot.data == null ||
-                            snapshot.data.toString() == 'null' ||
-                            snapshot.data == []
-                        // Load Individual WebId Input Dialog Screen without recipient list
-                        ? returnVal =
-                            _loadIndWebIdTextInput(widget.onSubmitFunction)
-                        // Load Individual WebId Input Dialog Screen with recipient list
-                        : returnVal = _loadIndWebIdTextInput(
-                            widget.onSubmitFunction,
-                            snapshot.data!,
-                          );
-                  } else {
-                    returnVal = loadingScreen(normalLoadingScreenHeight);
-                  }
-                  return returnVal;
-                },
-              ),
-      ),
-    );
+    return (widget.dataFilesMap.isNotEmpty)
+        ? _loadIndWebIdTextInput(
+            widget.onSubmitFunction,
+            uniqRecipWebIdList,
+          )
+        : FutureBuilder(
+            future: _asyncGetRecipList,
+            builder: (context, snapshot) {
+              Widget returnVal;
+              if (snapshot.connectionState == ConnectionState.done) {
+                return snapshot.data == null ||
+                        snapshot.data.toString() == 'null' ||
+                        snapshot.data == []
+                    // Load Individual WebId Input Dialog Screen without recipient list
+                    ? returnVal =
+                        _loadIndWebIdTextInput(widget.onSubmitFunction)
+                    // Load Individual WebId Input Dialog Screen with recipient list
+                    : returnVal = _loadIndWebIdTextInput(
+                        widget.onSubmitFunction,
+                        snapshot.data!,
+                      );
+              } else {
+                returnVal = loadingScreen(normalLoadingScreenHeight);
+              }
+              return returnVal;
+            },
+          );
   }
 }


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Fixed individual recipient webid dialog so that the app background shows so that this dialog window is consistent with others, and that the solid scaffold is shown.
- This PR relates to issue #526 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

notepod on ios:

1. Click share icon on a note and click individual recipient

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [x] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [x] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
  - [ ] Web
- [x] I have identified reviewers
- [ ] The PR has been approved by reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
