### PR TITLE
fixes heading colour in grant permission page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Visit the package at [pub.dev](https://pub.dev/packages/solidpod).
 
 ## 0.10 Further UI migrations
 
++ Fix sharing page heading colours [0.9.2 20260113 jesscmoore]
 + Fixes key creation for encrypting files [0.9.2 20260112 dc]
 + Code cleanup: typos, context checks, remove context/child [0.9.1 20260112 jesscmoore]
 + Updated read/write to remove context and widget [0.9.0 20260108 dc]

--- a/lib/src/solid/grant_permission_ui.dart
+++ b/lib/src/solid/grant_permission_ui.dart
@@ -470,7 +470,8 @@ class GrantPermissionUiState extends State<GrantPermissionUi>
 
     final form = getForm(
       formKey: formKey,
-      welcomeHeading: buildHeading(getWelcomeStr(widget.resourceName), 22),
+      welcomeHeading:
+          buildHeading(getWelcomeStr(widget.resourceName), 22, Colors.blueGrey),
       children: [
         if (widget.resourceName == null) ...[
           getResourceForm(


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Shared for considering styling in GrantPermissionUI when light/dark theme switched - see screenshots in issue. Colors should be migrated to a class before merging
- This PR relates to issue #528

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

notepod: open sharing page and switch themes

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [x] Screenshots included in linked issue #
- [ ] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] The update contains no confidential information
- [ ] The update has no duplicated content
- [ ] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [x] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
  - [ ] Web
- [ ] I have identified reviewers
- [ ] The PR has been approved by reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
