### PR TITLE
standardised use of colour in permission granting/revoking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Visit the package at [pub.dev](https://pub.dev/packages/solidpod).
 
 ## 0.10 Further UI migrations
 
++ Standardise action message colors [0.9.9 20260116 jesscmoore]
 + Support custom folder structure [0.9.8 20260114 anushkavid]
 + Restore individual recipient suggestions [0.9.7 20260113 jesscmoore]
 + Allow sharing externally owned files [0.9.6 20260110 jesscmoore]

--- a/lib/src/solid/constants/ui.dart
+++ b/lib/src/solid/constants/ui.dart
@@ -30,6 +30,26 @@ library;
 
 import 'package:flutter/material.dart';
 
+// Standard colours for actions and results.
+
+class ActionColors {
+  /// Green colour used for success
+
+  static const success = Colors.green;
+
+  // Red colour used for error/failure
+
+  static const error = Colors.red;
+
+  // Colour used for warning
+
+  static const warning = Color.fromARGB(255, 204, 99, 1);
+
+  // Red colour used for delete action
+
+  static const delete = Colors.red;
+}
+
 /// Colours used across security dialogs and prompts.
 
 class SecurityColors {

--- a/lib/src/solid/grant_permission_helper.dart
+++ b/lib/src/solid/grant_permission_helper.dart
@@ -108,8 +108,6 @@ void debugPrintFailure(
   debugPrint(getPermissionMsg(permissionList));
 }
 
-const warnBgColor = Color.fromARGB(255, 204, 99, 1);
-
 /// Small vertical spacing for the widget.
 const smallGapV = SizedBox(height: 10.0);
 

--- a/lib/src/solid/grant_permission_ui.dart
+++ b/lib/src/solid/grant_permission_ui.dart
@@ -555,7 +555,7 @@ class GrantPermissionUiState extends State<GrantPermissionUi>
               }
 
               if (result == SolidFunctionCallStatus.success) {
-                _showSnackBar(successMsg, Colors.green);
+                _showSnackBar(successMsg, ActionColors.success);
                 await _updatePermissions(
                   dataFile,
                   isFile: getIsFile(),
@@ -569,12 +569,12 @@ class GrantPermissionUiState extends State<GrantPermissionUi>
                 widget.onPermissionGranted?.call();
               } else if (result == SolidFunctionCallStatus.fail) {
                 // More detailed error message with troubleshooting tips
-                _showSnackBar(failureMsg, Colors.red);
+                _showSnackBar(failureMsg, ActionColors.error);
 
                 // Also log to console for debugging
                 debugPrintFailure(dataFile, finalWebIdList, selectedPermList);
               } else if (result == SolidFunctionCallStatus.notInitialised) {
-                _showSnackBar(podNotInitMsg, warnBgColor);
+                _showSnackBar(podNotInitMsg, ActionColors.warning);
               } else {
                 await _alert(updatePermissionMsg);
               }

--- a/lib/src/widgets/file_permission_data_table.dart
+++ b/lib/src/widgets/file_permission_data_table.dart
@@ -34,6 +34,7 @@ library;
 import 'package:flutter/material.dart' hide Key;
 
 import 'package:solidpod/src/solid/constants/common.dart';
+import 'package:solidpod/src/solid/constants/ui.dart';
 import 'package:solidpod/src/solid/constants/web_acl.dart';
 import 'package:solidpod/src/solid/revoke_permission.dart';
 import 'package:solidpod/src/solid/utils/snack_bar.dart';
@@ -127,7 +128,7 @@ Widget buildPermDataTable({
                 icon: const Icon(
                   Icons.delete,
                   size: 24.0,
-                  color: Colors.red,
+                  color: ActionColors.delete,
                 ),
                 onPressed: () {
                   showDialog(
@@ -164,7 +165,7 @@ Widget buildPermDataTable({
                                 showSnackBar(
                                   context,
                                   'Permission revoked successfully!',
-                                  Colors.red,
+                                  ActionColors.success,
                                 );
                               }
                               await updatePermissionsFunction(


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Standardised colour use in granting and revoking.
- This PR relates to issue #536

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

ios ipad simulator - granted and revoked access to a note to an individual in Notepad

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [x] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [x] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
  - [ ] Web
- [x] I have identified reviewers
- [ ] The PR has been approved by reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
