### PR TITLE
removed coloured background in loadingScreen()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Visit the package at [pub.dev](https://pub.dev/packages/solidpod).
 
 ## 0.10 Further UI migrations
 
++ Fixes backgroun of loadingScreen [0.9.17]
 + Optimise shared individual key loading and retrieval [0.9.15 20260128 cdawei]
 + Restored retrieve permissions button [0.9.14 20260125 jesscmoore]
 + Export ResourceNotExistException [0.9.13 20260123 tonypioneer]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Visit the package at [pub.dev](https://pub.dev/packages/solidpod).
 
 ## 0.10 Further UI migrations
 
-+ Fixes backgroun of loadingScreen [0.9.17]
++ Fixes background of loadingScreen [0.9.17 20260128 jesscmoore]
 + Optimise shared individual key loading and retrieval [0.9.15 20260128 cdawei]
 + Restored retrieve permissions button [0.9.14 20260125 jesscmoore]
 + Export ResourceNotExistException [0.9.13 20260123 tonypioneer]

--- a/lib/src/widgets/loading_screen.dart
+++ b/lib/src/widgets/loading_screen.dart
@@ -46,9 +46,6 @@ Widget loadingScreen(double height) {
     children: <Widget>[
       Container(
         alignment: AlignmentDirectional.center,
-        decoration: const BoxDecoration(
-          color: Colors.white,
-        ),
         child: Container(
           decoration: BoxDecoration(
             color: lightBlue,


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- removed white background behind solidpod loadingScreen() used in GrantPermissionUI and sharing resources UI and file explorer

## Associated Issue

- This PR relates to issue #540 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [x] Screenshots included in linked issue #540 
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [ ] Windows
  - [ ] Web
- [x] I have identified reviewers
- [ ] The PR has been approved by reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
