### PR TITLE
Revert to previous file_picker API

### DIFF
--- a/example/lib/features/file_service.dart
+++ b/example/lib/features/file_service.dart
@@ -128,7 +128,7 @@ class _FileServiceState extends State<FileService> {
   Widget build(BuildContext context) {
     final browseButton = ElevatedButton(
       onPressed: () async {
-        final result = await FilePicker.pickFiles();
+        final result = await FilePicker.platform.pickFiles();
         if (result != null) {
           setState(() {
             uploadFile = result.files.single.path!;
@@ -198,7 +198,7 @@ class _FileServiceState extends State<FileService> {
               deleteInProgress)
           ? null
           : () async {
-              String? outputFile = await FilePicker.saveFile(
+              String? outputFile = await FilePicker.platform.saveFile(
                 dialogTitle: 'Please set the output file:',
                 // fileName: 'download.bin',
               );
@@ -254,7 +254,7 @@ class _FileServiceState extends State<FileService> {
               deleteInProgress)
           ? null
           : () async {
-              String? outputFile = await FilePicker.saveFile(
+              String? outputFile = await FilePicker.platform.saveFile(
                 dialogTitle: 'Please set the output file:',
               );
               if (outputFile == null) {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   editable: ^2.0.0
-  file_picker: ^10.3.9
+  file_picker: ^10.3.10
   flutter:
     sdk: flutter
   intl: any
@@ -24,7 +24,7 @@ dependency_overrides:
   solidui:
     git:
       url: https://github.com/anusii/solidui
-      ref: dev
+      ref: revert-181-dc/update_filepicker_pkg
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,7 +24,7 @@ dependency_overrides:
   solidui:
     git:
       url: https://github.com/anusii/solidui
-      ref: revert-181-dc/update_filepicker_pkg
+      ref: dev
 
 dev_dependencies:
   flutter_lints: ^6.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,7 +44,7 @@ dev_dependencies:
   demopod:
     path: example
   editable: ^2.0.0
-  file_picker: ^10.3.9
+  file_picker: ^10.3.10
   flutter_lints: ^6.0.0
   import_order_lint: ^0.2.2
   # Keep dependency checker quiet.


### PR DESCRIPTION
# Pull Request Details

## What issue does this PR address

- Adapt code appropriately as `file_picker-v10.3.10` has [reverted a breaking change](https://github.com/miguelpruivo/flutter_file_picker/blob/master/CHANGELOG.md#10310) made in `v10.3.9`. 

## Associated Issue

- This PR relates to issue: N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist

Complete the check-list below to ensure your branch is ready for PR.

- [ ] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [ ] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] MacOS
  - [ ] Windows
  - [ ] Web
- [x] I have identified reviewers
- [ ] The PR has been approved by reviewers

## Finalising

Once PR discussion is complete and reviewers have approved:

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
