### PR TITLE
Jess/638 fix ind key saving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Visit the package at [pub.dev](https://pub.dev/packages/solidpod).
 
 ## 0.13
 
++ Fixes individual key file saving edge cases [0.12.5 20260427 jesscmoore]
 + Support user profile. [0.12.4 20260421 tonypioneer]
 + Key map + paths updates. Update file_picker. [0.12.3 20260420 jesscmoore]
 + Add silentLogout() [0.12.2 20260325 tonypioneer]

--- a/lib/solidpod.dart
+++ b/lib/solidpod.dart
@@ -84,6 +84,7 @@ export 'src/solid/utils/exceptions.dart'
         AccessForbiddenException,
         AccessFailedException,
         NotLoggedInException,
+        ResourceNotDecryptableException,
         ResourceNotExistException,
         SecurityKeyNotAvailableException;
 

--- a/lib/src/solid/utils/exceptions.dart
+++ b/lib/src/solid/utils/exceptions.dart
@@ -55,6 +55,15 @@ class ResourceNotExistException implements Exception {
   String toString() => 'ResourceNotExistException: $message';
 }
 
+class ResourceNotDecryptableException implements Exception {
+  final String message;
+
+  ResourceNotDecryptableException(this.message);
+
+  @override
+  String toString() => 'ResourceNotDecryptableException: $message';
+}
+
 class NotLoggedInException implements Exception {
   final String message;
 

--- a/lib/src/solid/utils/individual_key_manager.dart
+++ b/lib/src/solid/utils/individual_key_manager.dart
@@ -140,14 +140,9 @@ class IndividualKeyManager {
     );
     _indKeyMap![resourceUrl] = record;
 
-    final query = await getIndKeyQuery(
-      record,
-      operation: SparqlOperation.insert,
-      isFile: isFile,
-    );
-    _indKeyUrl ??= await getFileUrl(await getIndKeyPath());
-
-    await updateFileByQuery(_indKeyUrl!, query);
+    // Use full PUT overwrite instead of SPARQL PATCH — CSS servers may accept
+    // the PATCH request (HTTP 200) without actually persisting the triples.
+    await saveIndividualKeys(_indKeyMap);
   }
 
   /// Remove the (encrypted) individual key for file.
@@ -163,18 +158,12 @@ class IndividualKeyManager {
     assert(_indKeyMap != null);
 
     if (_indKeyMap!.containsKey(resourceUrl)) {
-      final record = _indKeyMap!.remove(resourceUrl);
-      assert(record != null);
+      _indKeyMap!.remove(resourceUrl);
 
-      final query = await getIndKeyQuery(
-        record!,
-        operation: SparqlOperation.delete,
-        isFile: isFile,
-      );
-      _indKeyUrl ??= await getFileUrl(await getIndKeyPath());
-      await updateFileByQuery(_indKeyUrl!, query);
+      // Use full PUT overwrite instead of SPARQL PATCH.
+      await saveIndividualKeys(_indKeyMap);
 
-      debugPrint('Deleted $record');
+      debugPrint('Deleted individual key for $resourcePath');
     } else {
       debugPrint(
         'Individual key for "$resourcePath" does not exist, do nothing.',

--- a/lib/src/solid/utils/key_helper.dart
+++ b/lib/src/solid/utils/key_helper.dart
@@ -326,8 +326,9 @@ Future<String> genIndKeyTTLStr(
       final resourceUrl = entry.key;
       final record = entry.value;
 
-      final indKey = record.key;
-      assert(indKey != null);
+      // [20260427 jesscmoore] Removed the assert that record.key is not null, as it prevents first file being written to pod.
+      // final indKey = record.key;
+      // assert(indKey != null);
 
       triples[URIRef(resourceUrl)] = {
         solidTermsNS.ns.withAttr(pathPred): record.resourcePath,

--- a/lib/src/solid/utils/shared_key_manager.dart
+++ b/lib/src/solid/utils/shared_key_manager.dart
@@ -36,6 +36,7 @@ import 'package:rdflib/rdflib.dart' show Namespace;
 
 import 'package:solidpod/src/solid/api/rest_api.dart';
 import 'package:solidpod/src/solid/constants/schema.dart' show appsResId;
+import 'package:solidpod/src/solid/utils/exceptions.dart';
 import 'package:solidpod/src/solid/utils/get_url_helper.dart';
 import 'package:solidpod/src/solid/utils/key_helper.dart';
 import 'package:solidpod/src/solid/utils/misc.dart';
@@ -141,14 +142,22 @@ class SharedKeyManager {
     assert(record != null);
 
     if (record!.key == null) {
-      _rsaEncrypter ??= Encrypter(
-        RSA(privateKey: RSAKeyParser().parse(privateKey) as RSAPrivateKey),
-      );
+      try {
+        _rsaEncrypter ??= Encrypter(
+          RSA(privateKey: RSAKeyParser().parse(privateKey) as RSAPrivateKey),
+        );
 
-      record.resourcePath = _rsaEncrypter!.decrypt64(record.encResourcePath);
-      record.accessList = _rsaEncrypter!.decrypt64(record.encAccessList);
-      record.key = Key.fromBase64(_rsaEncrypter!.decrypt64(record.encKey));
-      _sharedIndKeyMap![uniqueIdUrl] = record;
+        record.resourcePath = _rsaEncrypter!.decrypt64(record.encResourcePath);
+        record.accessList = _rsaEncrypter!.decrypt64(record.encAccessList);
+        record.key = Key.fromBase64(_rsaEncrypter!.decrypt64(record.encKey));
+        _sharedIndKeyMap![uniqueIdUrl] = record;
+      } on ArgumentError catch (e) {
+        // RSA decryption failed — the shared key was encrypted with a different
+        // public key (e.g. after pod re-initialisation rotated the key pair).
+        throw ResourceNotDecryptableException(
+          'Cannot decrypt shared key for $resourceUrl: $e',
+        );
+      }
     }
 
     return record.key!;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidpod
 description: Support access to private data from PODs on Solid servers.
-version: 0.12.4
+version: 0.12.5
 homepage: https://github.com/anusii/solidpod
 
 environment:


### PR DESCRIPTION
## Pull Request Details

### Description
<!--- Describe the problem this PR solves -->
<!--- Describe what you have changed -->
<!--- Describe why this change is required -->

- Overwriting with PUT the individual key file is more stable than patching additional keys. This fix ensures that new individual keys for new files are written to the individual key file in a user's folder and not just accessible through memory. In past, sometimes new individual keys were not being appended to the key file.
- Fixes scenario where a user has re-initialised their pod with a new master key, hence files previously accessible are no longer decryptable, as the key cannot be decrypted in the user's call to readExternalPod(). This was the scenario for charliesolidtester on notepod
- Removes an assert that prevents the first file from being written to a user's pod

### Related Issues
<!--- If it fixes an open issue(s), please link to the issue here. -->

- issue #638 https://github.com/anusii/solidpod/issues/638

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How To Test?
<!--- Describe the tests that a reviewer can undertake to verify your changes. -->

- Test by creating new files and saving them, eg notes in notepod.
- Removing all of a user's notes. Logging out and back in. Creating and saving first note.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [ ] The update has no duplicated content
- [ ] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [x] iOS
  - [ ] Linux
  - [ ] MacOS
  - [ ] Windows
  - [ ] Web
- [x] I have identified reviewers
- [ ] The PR has been approved by reviewers

### Finalising
<!--- Once PR discussion is complete and reviewers have approved. -->

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
