### PR TITLE
Av/693 streamline login logout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 ARCHIVE
 ignore
+pubspec_overrides.yaml
 pubspec.yaml.*
 !templates/solidpod/pubspec.yaml.tmpl
 !templates/solidui/pubspec.yaml.tmpl

--- a/lib/solidpod.dart
+++ b/lib/solidpod.dart
@@ -60,6 +60,7 @@ export 'src/solid/constants/predicates.dart';
 export 'src/solid/authenticate.dart'
     show
         solidAuthenticate,
+        prewarmSolidAuthenticate,
         tryRestoreSession,
         pickRedirectUri,
         cancelSolidAuthenticate;

--- a/lib/src/solid/authenticate.dart
+++ b/lib/src/solid/authenticate.dart
@@ -36,6 +36,8 @@ import 'package:flutter/foundation.dart'
     show debugPrint, defaultTargetPlatform, kIsWeb, TargetPlatform;
 import 'package:flutter/material.dart' show BuildContext;
 
+import 'package:oidc/oidc.dart' show OidcPlatformSpecificOptions;
+
 import 'package:solid_auth/solid_auth.dart'
     show SolidAuthManager, SolidOidcConfig;
 
@@ -115,6 +117,71 @@ void cancelSolidAuthenticate() {
   // unawaited(cancelAuthenticate());
 }
 
+// State cached by prewarmSolidAuthenticate() and consumed (then cleared) by
+// the next solidAuthenticate() call, so long as its parameters match.
+SolidAuthManager? _prewarmedManager;
+String? _prewarmedServerId;
+String? _prewarmedClientId;
+String? _prewarmedRedirectUri;
+OidcPlatformSpecificOptions? _prewarmedOidcOptions;
+
+void _clearPrewarmedManager() {
+  _prewarmedManager = null;
+  _prewarmedServerId = null;
+  _prewarmedClientId = null;
+  _prewarmedRedirectUri = null;
+  _prewarmedOidcOptions = null;
+}
+
+/// Resolves [serverId]'s issuer and initialises the underlying OIDC manager
+/// ahead of time, so a later [solidAuthenticate] call with the exact same
+/// [serverId], [clientId], [redirectUris], and [oidcOptions] can skip
+/// straight to the browser redirect.
+///
+/// This exists for Safari: `window.open()` must fire within the same
+/// user-gesture handling as the login button's click, but [solidAuthenticate]
+/// normally awaits a WebID HTTP GET and an OIDC discovery-document GET first,
+/// which pushes it past that window and gets the popup silently blocked.
+/// Call this speculatively — e.g. when the login screen first shows a fixed
+/// default server — so the button click reuses an already-initialised
+/// manager instead. Failures are swallowed; [solidAuthenticate] will simply
+/// redo the work from scratch.
+Future<void> prewarmSolidAuthenticate(
+  String serverId, {
+  required String clientId,
+  required List<String> redirectUris,
+  List<String> postLogoutRedirectUris = const [],
+  OidcPlatformSpecificOptions? oidcOptions,
+}) async {
+  if (clientId.isEmpty || redirectUris.isEmpty) return;
+  try {
+    if (await isUserLoggedIn()) return;
+
+    final effectiveRedirectUri = pickRedirectUri(redirectUris);
+    final effectivePostLogoutUri = postLogoutRedirectUris.isNotEmpty
+        ? pickRedirectUri(postLogoutRedirectUris)
+        : effectiveRedirectUri;
+
+    final manager = SolidAuthManager(
+      config: SolidOidcConfig(
+        clientId: clientId,
+        redirectUri: Uri.parse(effectiveRedirectUri),
+        postLogoutRedirectUri: Uri.parse(effectivePostLogoutUri),
+        options: oidcOptions,
+      ),
+    );
+    await manager.prewarm(serverId);
+
+    _prewarmedManager = manager;
+    _prewarmedServerId = serverId;
+    _prewarmedClientId = clientId;
+    _prewarmedRedirectUri = effectiveRedirectUri;
+    _prewarmedOidcOptions = oidcOptions;
+  } on Object catch (e) {
+    debugPrint('prewarmSolidAuthenticate() failed: $e');
+  }
+}
+
 /// Asynchronously authenticate a user against a Solid server [serverId].
 ///
 /// [serverId] is the user's WebID or an issuer URI. Issuer resolution is
@@ -140,6 +207,18 @@ void cancelSolidAuthenticate() {
 /// [postLogoutRedirectUris] works the same way for the post-logout redirect.
 /// Defaults to the same selection as [redirectUris] when omitted.
 ///
+/// [oidcOptions] passes through platform-specific `package:oidc` settings.
+/// On web, the default navigation mode opens a new popup/tab via
+/// `window.open()`, which Safari's popup blocker silently blocks because it
+/// fires after the async WebID/issuer-discovery lookups below rather than
+/// synchronously within the click handler. Call [prewarmSolidAuthenticate]
+/// ahead of the click to remove those awaits from this call's path instead.
+///
+/// `OidcPlatformSpecificOptions_Web_NavigationMode.samePage` avoids the
+/// popup entirely via a full-page redirect, but the browser fully reloads
+/// mid-flow, so any code awaiting this call never resumes — only pass it if
+/// your caller doesn't rely on that continuation running (solidui's stock
+/// widgets do, so don't set this when using them).
 ///
 /// Returns `[SolidAuthData, webId, profileTurtle]` on success, null on failure.
 Future<List<dynamic>?> solidAuthenticate(
@@ -148,6 +227,7 @@ Future<List<dynamic>?> solidAuthenticate(
   required String clientId,
   required List<String> redirectUris,
   List<String> postLogoutRedirectUris = const [],
+  OidcPlatformSpecificOptions? oidcOptions,
 }) async {
   try {
     // Return existing session without re-authenticating.
@@ -182,13 +262,24 @@ Future<List<dynamic>?> solidAuthenticate(
         ? pickRedirectUri(postLogoutRedirectUris)
         : effectiveRedirectUri;
 
-    final authManager = SolidAuthManager(
-      config: SolidOidcConfig(
-        clientId: clientId,
-        redirectUri: Uri.parse(effectiveRedirectUri),
-        postLogoutRedirectUri: Uri.parse(effectivePostLogoutUri),
-      ),
-    );
+    // Reuse the manager warmed up by prewarmSolidAuthenticate() when it
+    // matches this call's parameters — that's what lets the redirect below
+    // fire without first re-running the WebID lookup and discovery fetch.
+    final authManager = (_prewarmedManager != null &&
+            _prewarmedServerId == serverId &&
+            _prewarmedClientId == clientId &&
+            _prewarmedRedirectUri == effectiveRedirectUri &&
+            _prewarmedOidcOptions == oidcOptions)
+        ? _prewarmedManager!
+        : SolidAuthManager(
+            config: SolidOidcConfig(
+              clientId: clientId,
+              redirectUri: Uri.parse(effectiveRedirectUri),
+              postLogoutRedirectUri: Uri.parse(effectivePostLogoutUri),
+              options: oidcOptions,
+            ),
+          );
+    _clearPrewarmedManager();
 
     final solidAuthData = await authManager.authenticate(serverId);
     if (solidAuthData == null) return null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,12 +29,15 @@ dependencies:
   intl: ^0.20.2
   jwt_decoder: ^2.0.1
   mime: ^2.0.0
+  oidc: ^0.14.0
   package_info_plus: ^9.0.0
   path: ^1.9.1
   petitparser: ^6.1.0
   pointycastle: ^4.0.0
   rdflib: ^0.2.12
-  solid_auth: ^1.0.2
+  # solid_auth: ^1.0.2
+  solid_auth:
+    path: ../solid_auth
   universal_io: ^2.3.1
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,7 +37,9 @@ dependencies:
   rdflib: ^0.2.12
   # solid_auth: ^1.0.2
   solid_auth:
-    path: ../solid_auth
+    git:
+      url: https://github.com/anusii/solid_auth.git
+      ref: av/693_streamline_login_logout
   universal_io: ^2.3.1
 
 dev_dependencies:


### PR DESCRIPTION
## Pull Request Details

### Description
<!--- Describe the problem this PR solves -->
<!--- Describe what you have changed -->
<!--- Describe why this change is required -->

- Add `prewarmSolidAuthenticate()`: builds a `SolidAuthManager`, calls its new `prewarm()`, and caches it; `solidAuthenticate()` reuses that cached manager when `serverId`/`clientId`/`redirectUri`/`oidcOptions` all match, then clears the cache either way.
- `solidAuthenticate()` gains an optional `oidcOptions` passthrough to `SolidOidcConfig` (defaults to `null`, no behaviour change) for callers who want to set `package:oidc` platform options directly.
- Add `oidc` as a direct dependency (was already resolved transitively via `solid_auth`).

#### Why
Companion to the solid_auth PR: https://github.com/anusii/solid_auth/pull/50 closes the gap where Safari/Brave silently blocks the login popup because `window.open()` fires after `solidAuthenticate()`'s WebID/issuer-discovery network round trips instead of synchronously with the click.

### Related Issues
<!--- If it fixes an open issue(s), please link to the issue here. -->
https://github.com/anusii/solidpod/issues/693

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How To Test?
<!--- Describe the tests that a reviewer can undertake to verify your changes. -->
Run the example app in corresponding branches of `solidui` with different Browser and OS combinations. See PR https://github.com/anusii/solidui/pull/402 for more details.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Screenshots included here/in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [x] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [ ] MacOS
  - [x] Windows
  - [ ] Web
- [ ] I have identified reviewers
- [ ] The PR has been approved by reviewers

### Finalising
<!--- Once PR discussion is complete and reviewers have approved. -->

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
