### PR TITLE
dc/705 pod resource url

### DIFF
--- a/lib/src/solid/authenticate.dart
+++ b/lib/src/solid/authenticate.dart
@@ -37,7 +37,6 @@ import 'package:flutter/foundation.dart'
 import 'package:flutter/material.dart' show BuildContext;
 
 import 'package:oidc/oidc.dart' show OidcPlatformSpecificOptions;
-
 import 'package:solid_auth/solid_auth.dart'
     show SolidAuthManager, SolidOidcConfig;
 

--- a/lib/src/solid/utils/get_url_helper.dart
+++ b/lib/src/solid/utils/get_url_helper.dart
@@ -62,7 +62,23 @@ Future<String> _getResourceUrl(
   assert(wId != null);
   assert(wId!.contains(profCard));
 
-  final resourceUrl = wId!.replaceAll(profCard, resourcePath);
+  // final resourceUrl = wId!.replaceAll(profCard, resourcePath);
+
+  final uri = Uri.tryParse(wId!);
+
+  if (uri == null) {
+    throw Exception('WebID is null');
+  }
+
+  if (uri.pathSegments.isEmpty) {
+    throw Exception('Invalide WebID ($wId)');
+  }
+
+  final resourceUrl = [
+    uri.origin,
+    uri.pathSegments.first,
+    resourcePath,
+  ].join('/');
 
   if (!isFile && !resourceUrl.endsWith('/')) {
     return '$resourceUrl/';


### PR DESCRIPTION
## Pull Request Details

### Description
- Closes #705 
- Updates code that generates URL of resources in POD, such that it is compatible with the format of `solidpod` and [`privatedatapod`](https://privatedatapod.com).
- Resource URL for current `solidpod`: `https://server_url/user_name/app_name/path/to/resource`
- Resource URL for [`privatedatapod`](https://privatedatapod.com): `https//user_name.privatedatapod.com/profile/app_name/path/to/resource`

### Related Issues
#705 

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How To Test?
To test the changes, please
- Register a POD from https://privatedatapod.com, the corresponding web ID is `https://your_user_name.privatedatapod.com/profile/card#me`
- Build a solidui-based app (e.g., solidui example app) using solidpod branch [dc/705_pod_resource_url](https://github.com/anusii/solidpod/tree/dc/705_pod_resource_url) and start the app
- Set the server URL in the login page to `https://privatedatapod.com`
- Login with your account on [privatedatapod](https://privatedatapod.com)
- Click `Read/Write Pod Data File` button to add a key-value pair, then click `Submit` etc.
- Test the same app using another account on, e.g., https://dev.solidcommunity.au.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] Screenshots included here/in linked issue #705 
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [x] Linux
  - [ ] MacOS
  - [ ] Windows
  - [ ] Web
- [x] I have identified reviewers
- [ ] The PR has been approved by reviewers

### Finalising
<!--- Once PR discussion is complete and reviewers have approved. -->

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
