### PR TITLE
Single-flight session restore so startup no longer clears the session

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
     types: [opened, reopened, synchronize]
 
 env:
-  FLUTTER_VERSION: '3.47.0'
+  FLUTTER_VERSION: '3.47.3'
 
 jobs:
 

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -101,6 +101,8 @@ https://solid.dev.empwr.au/alice/profile/card#me
 https://solid.dev.empwr.au/Analyser
 https://www.heart.org/
 https://www.heart.org/en/health-topics/high-blood-pressure/understanding-blood-pressure-readings
+https://solid.dev.empwr.au/bob/profile/card#me
+https://snapcraft.io/healthpod
 
 # 20260605 gjw Failing solid servers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Visit the package at [pub.dev](https://pub.dev/packages/solidpod).
 
 ## 1.0
 
++ Fix always being asked to log in again on startup [1.0.22 20260911 gjw]
 + Disable caching for web [1.0.21 20260908 jesscmoore]
 + Migrate oidc from 0->4 [1.0.20 20260904 gjw]
 + Update dependency (including rdf 1.0.0, renamed from rdflib) [1.0.19]

--- a/lib/src/solid/utils/authdata_manager.dart
+++ b/lib/src/solid/utils/authdata_manager.dart
@@ -87,18 +87,43 @@ class AuthDataManager {
     authStateNotifier.value = true;
   }
 
+  /// The restore currently in flight, shared by concurrent callers.
+  static Future<SolidAuthData?>? _restoreInFlight;
+
+  /// The token refresh currently in flight, shared by concurrent callers.
+  static Future<SolidAuthData?>? _refreshInFlight;
+
   /// Returns current [SolidAuthData], refreshing the token if expired.
   ///
   /// If no in-memory manager exists, attempts to restore the session from
   /// secure storage using [SolidAuthManager.initForIssuer].  Returns null
   /// when the session cannot be restored (forces re-login).
-  static Future<SolidAuthData?> loadAuthData() async {
+  ///
+  /// Concurrent callers share a single restore (and a single refresh) rather
+  /// than each starting their own. Both paths end in a `refresh_token` grant,
+  /// and the Solid server issues single-use refresh tokens: a second grant
+  /// sent with the same token is rejected as `invalid_grant`, and
+  /// [SolidAuthManager.tryRestoreSession] responds to that failure by clearing
+  /// the stored session — discarding the session the first caller had just
+  /// successfully refreshed. On startup two callers are routine (solidui's
+  /// auto-login and its login-status notifier both run on the first frame),
+  /// so without this the session is destroyed on every launch.
+  static Future<SolidAuthData?> loadAuthData() {
     // Check if live manager already in memory.
     if (_authManager != null) {
-      return _getRefreshedAuthData(_authManager!);
+      return _refreshInFlight ??= _getRefreshedAuthData(
+        _authManager!,
+      ).whenComplete(() => _refreshInFlight = null);
     }
 
-    // Slow path: try to restore from secure storage.
+    return _restoreInFlight ??= _restoreFromStorage().whenComplete(
+      () => _restoreInFlight = null,
+    );
+  }
+
+  /// Restores the session from secure storage. Call via [loadAuthData], which
+  /// ensures only one restore runs at a time.
+  static Future<SolidAuthData?> _restoreFromStorage() async {
     final dataStr = await secureStorage.read(key: _authDataSecureStorageKey);
     if (dataStr == null) return null;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,18 @@ dependencies:
   solid_auth: ^1.0.8
   universal_io: ^2.3.1
 
+# 20260911 gjw TEMPORARY. The published solidpod and solid_auth clear the
+# session on every start, so the login page always appears — see
+# anusii/solidpod#717 and anusii/solid_auth#53. These overrides pick up the
+# fixes from the GitHub fix branches. Remove this section once both are
+# released.
+
+dependency_overrides:
+  solid_auth:
+    git:
+      url: https://github.com/anusii/solid_auth.git
+      ref: gjw/52_secure_token_store
+
 dev_dependencies:
   build_runner: ^2.15.1
   custom_lint: ^0.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: solidpod
 description: Support access to private data from PODs on Solid servers.
-version: 1.0.21
+version: 1.0.22
 homepage: https://github.com/anusii/solidpod
 
 environment:
@@ -35,7 +35,7 @@ dependencies:
   petitparser: ^7.0.2
   pointycastle: ^4.0.0
   rdf: ^1.0.0
-  solid_auth: ^1.0.7
+  solid_auth: ^1.0.8
   universal_io: ^2.3.1
 
 dev_dependencies:

--- a/support/flutter.mk
+++ b/support/flutter.mk
@@ -317,6 +317,8 @@ todo:
 license:
 	@echo "Files without a LICENSE:\n"
 	@-output=$$(find lib -type f -not -name '*~' -not -name 'README*' -not -name '*.g.dart' \
+	  -not -name '*.pb.dart' -not -name '*.pbenum.dart' \
+	  -not -name '*.pbjson.dart' -not -name '*.pbgrpc.dart' -not -name '*.proto' \
 	! -exec grep -qE '^(///? Copyright|///? Licensed)' {} \; -print | xargs printf "\t%s\n"); \
 	if [ $$(echo "$$output" | wc -w) -ne 0 ]; then \
 		echo "$$output"; \

--- a/support/update.sh
+++ b/support/update.sh
@@ -37,6 +37,22 @@ FILES=(
     ${SCRIPTS}Makefile Makefile
 )
 
+# 20260911 gjw The android build configuration is app independent: the
+# app name only appears in android/app/build.gradle.kts (namespace,
+# applicationId) which stays local. Sharing these keeps the gradle,
+# AGP, and kotlin versions in step across all apps, which is what
+# flutter's build dependency validation warns about. Only add them
+# when the app builds for android.
+
+if [ -d android ]; then
+    FILES+=(
+	${SCRIPTS}flutter/android/build.gradle.kts android/build.gradle.kts
+	${SCRIPTS}flutter/android/settings.gradle.kts android/settings.gradle.kts
+	${SCRIPTS}flutter/android/gradle.properties android/gradle.properties
+	${SCRIPTS}flutter/android/gradle/wrapper/gradle-wrapper.properties android/gradle/wrapper/gradle-wrapper.properties
+    )
+fi
+
 length=${#FILES[@]}
 
 for ((i=0; i < length; i+=2)); do


### PR DESCRIPTION
Fixes the login page being shown on every start even while the session
was still valid.

## Problem

Two callers reach `AuthDataManager.loadAuthData()` on the first frame —
solidui's auto-login (`solid_login.dart:274`) and its login-status
notifier (`solid_login_status_notifier.dart:68`, via `isUserLoggedIn()` →
`getAccessToken()`). The slow path had no in-flight guard, and the
`await secureStorage.read` yields, so neither caller blocked the other:
both built their own `SolidAuthManager` and both POSTed a
`refresh_token` grant with the same stored token.

The server issues single-use refresh tokens, so the second grant came
back `invalid_grant`, and `tryRestoreSession()` responds to a failed
refresh by clearing the stored session — discarding the session the
first caller had just successfully refreshed. Deterministic rather than
intermittent, because both calls start in the same frame.

No solidpod code change caused this: `lib/` is byte-identical between
1.0.19 and 1.0.20. The trigger was the dependency bump in 1.0.20, where
solid_auth 1.0.7 sets `initMode: OidcInitMode.blockingValidate` and so
makes `init()` reach the token endpoint during restore — turning a
redundant-but-harmless double restore into a double spend.

## Fix

Concurrent callers now share one restore, and one refresh once a manager
is live, since that path double-spends the token the same way. The slow
path moved verbatim into `_restoreFromStorage()`; `loadAuthData()` is no
longer `async` so the `??=` assignment happens before any await point,
which is what closes the window.

A completing future cannot null out a newer in-flight future, because a
new one is only created once the field is already null.

## Testing

Verified with todopod on Linux desktop via a path override. Before, the
whole startup block appeared twice and ended in two `Clearing stored
session`. After:

```
INFO  Attempting to restore previous session          ×1  (was ×2)
INFO  Session restored for: .../profile/card#me       ×1  (was ×0)
      Stored tokens not found                         ×0  (was ×2)
      Clearing stored session                         ×0  (was ×2)
      Starting Solid-OIDC login                       ×0  (was ×1, forced)
```

The app goes straight to its data instead of the login page, and the
session held for the whole run — no clearing or forced login afterwards.

Worth noting `grant_type=refresh_token` was ×0 on the successful run:
the cached access token was still valid, so no refresh was needed. That
is the behaviour originally lost, and it confirms the mechanism — the old
code's two racing restores each forced a token-endpoint round trip and
destroyed a session that never needed refreshing.

## Not covered

Restore across an actually-expired access token, where a single refresh
does fire. That path is unexercised, so the rotating-token behaviour is
still unverified in practice.

Closes #716
